### PR TITLE
Graceful shutdown in Docker environments

### DIFF
--- a/src/graceful_shutdown.rs
+++ b/src/graceful_shutdown.rs
@@ -1,0 +1,27 @@
+use std::time::Duration;
+
+use tokio::signal::unix::{signal,SignalKind};
+use tracing::info;
+
+#[cfg(unix)]
+pub async fn wait_for_signal() {
+    let mut sigterm = signal(SignalKind::terminate())
+        .expect("Unable to register shutdown handler; are you running a Unix-based OS?");
+    let mut sigint = signal(SignalKind::interrupt())
+        .expect("Unable to register shutdown handler; are you running a Unix-based OS?");
+    let signal = tokio::select! {
+        _ = sigterm.recv() => "SIGTERM",
+        _ = sigint.recv() => "SIGINT"
+    };
+    // The following does not print in docker-compose setups but it does when run individually.
+    // Probably a docker-compose error.
+    info!("Received signal ({signal}) - shutting down gracefully.");
+}
+
+#[cfg(windows)]
+pub async fn wait_for_signal() {
+    if let Err(e) = tokio::signal::ctrl_c().await {
+        panic!("Unable to register shutdown handler: {e}.");
+    }
+    info!("Received shutdown signal - shutting down gracefully.");
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,7 +24,7 @@ use crate::{config::CONFIG, errors::FocusError};
 use laplace_rs::ObfCache;
 
 mod errors;
-
+mod graceful_shutdown;
 
 // result cache
 type SearchQuery = String;
@@ -48,6 +48,17 @@ pub async fn main() -> ExitCode {
 
     let _ = CONFIG.api_key; // Initialize config
 
+    tokio::select! {
+        _ = graceful_shutdown::wait_for_signal() => {
+            ExitCode::SUCCESS
+        },
+        code = main_loop() => {
+            code
+        }
+    }
+}
+
+async fn main_loop() -> ExitCode {
     let mut obf_cache: ObfCache = ObfCache {
         cache: HashMap::new(),
     };


### PR DESCRIPTION
This will make Beam quit a) gracefully and b) faster in Docker-based environments, where some signals are not forwarded into containers.

Compare https://github.com/samply/beam/pull/109