### PR TITLE
feat: Handle beam tasks asynchronously

### DIFF
--- a/src/blaze.rs
+++ b/src/blaze.rs
@@ -4,7 +4,9 @@ use serde::Serialize;
 use serde_json::Value;
 use tracing::{debug, warn};
 
+use crate::BeamTask;
 use crate::errors::FocusError;
+use crate::util;
 use crate::util::get_json_field;
 use crate::config::CONFIG;
 
@@ -119,4 +121,10 @@ pub async fn run_cql_query(library: &Value, measure: &Value) -> Result<String, F
     post_library(library.to_string()).await?; //TODO make it with into or could change the function signature to take the library
     post_measure(measure.to_string()).await?; //ditto   &str
     evaluate_measure(url).await
+}
+
+// This could be part of an impl of Cqlquery
+pub fn parse_blaze_query(task: &BeamTask) -> Result<CqlQuery, FocusError> {
+    let decoded = util::base64_decode(&task.body)?;
+    serde_json::from_slice(&decoded).map_err(|e| FocusError::ParsingError(e.to_string()))
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -11,13 +11,13 @@ use tracing::{debug, info, warn};
 use crate::errors::FocusError;
 
 
-#[derive(clap::ValueEnum, Clone, Debug)]
+#[derive(clap::ValueEnum, Clone, PartialEq, Debug)]
 pub enum Obfuscate {
     No,
     Yes,
 }
 
-#[derive(clap::ValueEnum, Clone, Debug, PartialEq, Copy)]
+#[derive(clap::ValueEnum, Clone, PartialEq, Debug, Copy)]
 pub enum EndpointType {
     Blaze,
     Omop,

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,10 +13,10 @@ mod task_processing;
 mod util;
 
 use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
-use beam_lib::{TaskRequest, TaskResult, MsgId};
+use beam_lib::{MsgId, TaskRequest, TaskResult};
 use laplace_rs::ObfCache;
-use tokio::sync::Mutex;
 use task_processing::TaskQueue;
+use tokio::sync::Mutex;
 
 use crate::util::{is_cql_tampered_with, obfuscate_counts_mr};
 use crate::{config::CONFIG, errors::FocusError};
@@ -35,6 +35,7 @@ use tracing::{debug, error, warn};
 
 // result cache
 type SearchQuery = String;
+type Obfuscated = bool;
 type Report = String;
 type Created = std::time::SystemTime; //epoch
 type BeamTask = TaskRequest<String>;
@@ -49,8 +50,36 @@ struct Metadata {
 
 #[derive(Debug, Clone, Default)]
 struct ReportCache {
-    cache: HashMap<SearchQuery, (Report, Created)>,
+    cache: HashMap<(SearchQuery, Obfuscated), (Report, Created)>,
 }
+
+impl ReportCache {
+ 
+    pub fn new() -> Self {
+        let mut cache = HashMap::new();
+ 
+        if let Some(filename) = CONFIG.queries_to_cache_file_path.clone() {
+            let lines = util::read_lines(filename.clone().to_string());
+            match lines {
+                Ok(ok_lines) => {
+                   for line in ok_lines {
+                       let Ok(ok_line) = line else {
+                           warn!("A line in the file {} is not readable", filename);
+                           continue;
+                       };
+                       cache.insert((ok_line.clone(), false), ("".into(), UNIX_EPOCH));
+                       cache.insert((ok_line, true), ("".into(), UNIX_EPOCH));
+                   }
+                },
+                Err(_) => {
+                   error!("The file {} cannot be opened", filename); //This shouldn't stop focus from running, it's just going to go to blaze every time, but that's not too slow
+                }
+            }
+        }
+ 
+        Self {cache}
+    }
+ }
 
 const REPORTCACHE_TTL: Duration = Duration::from_secs(86400); //24h
 
@@ -76,25 +105,7 @@ pub async fn main() -> ExitCode {
 
 async fn main_loop() -> ExitCode {
     // TODO: The report cache init should be an fn on the cache
-    let mut report_cache: ReportCache = Default::default();
-    if let Some(filename) = CONFIG.queries_to_cache_file_path.clone() {
-        let lines = util::read_lines(filename.clone().to_string());
-        match lines {
-            Ok(ok_lines) => {
-                for line in ok_lines {
-                    let Ok(ok_line) = line else {
-                        warn!("A line in the file {} is not readable", filename);
-                        continue;
-                    };
-                    report_cache.cache.insert(ok_line, ("".into(), UNIX_EPOCH));
-                }
-            }
-            Err(_) => {
-                error!("The file {} cannot be opened", filename);
-                exit(2);
-            }
-        }
-    }
+    let report_cache: ReportCache = ReportCache::new();
 
     let mut seen_tasks = Default::default();
     let mut task_queue = task_processing::spawn_task_workers(report_cache);
@@ -122,7 +133,7 @@ async fn main_loop() -> ExitCode {
 
         if let Err(e) = process_tasks(&mut task_queue, &mut seen_tasks).await {
             warn!("Encountered the following error, while processing tasks: {e}");
-            //failures += 1;
+            //failures += 1; //I believe this can be uncommented now
         } else {
             failures = 0;
         }
@@ -133,7 +144,6 @@ async fn main_loop() -> ExitCode {
     );
     ExitCode::from(22)
 }
-
 
 async fn process_tasks(
     task_queue: &mut TaskQueue,
@@ -147,11 +157,13 @@ async fn process_tasks(
             continue;
         }
         seen.insert(task.id);
-        task_queue.send(task).await.expect("Receiver is never dropped");
+        task_queue
+            .send(task)
+            .await
+            .expect("Receiver is never dropped");
     }
     Ok(())
 }
-
 
 async fn run_cql_query(
     task: &BeamTask,
@@ -170,7 +182,14 @@ async fn run_cql_query(
 
     let mut key_exists = false;
 
-    let report_from_cache = match report_cache.lock().await.cache.get(encoded_query) {
+    let obfuscate = CONFIG.obfuscate == config::Obfuscate::Yes && !CONFIG.unobfuscated.contains(&project);
+
+    let report_from_cache = match report_cache
+        .lock()
+        .await
+        .cache
+        .get(&(encoded_query.to_string(), obfuscate))
+    {
         Some(existing_report) => {
             key_exists = true;
             if SystemTime::now().duration_since(existing_report.1).unwrap() < REPORTCACHE_TTL {
@@ -189,32 +208,26 @@ async fn run_cql_query(
 
             let cql_result = blaze::run_cql_query(&query.lib, &query.measure).await?;
 
-            let cql_result_new: String = match CONFIG.obfuscate {
-                config::Obfuscate::Yes => {
-                    if !CONFIG.unobfuscated.contains(&project) {
-                        obfuscate_counts_mr(
-                            &cql_result,
-                            obf_cache.lock().await.deref_mut(),
-                            CONFIG.obfuscate_zero,
-                            CONFIG.obfuscate_below_10_mode,
-                            CONFIG.delta_patient,
-                            CONFIG.delta_specimen,
-                            CONFIG.delta_diagnosis,
-                            CONFIG.delta_procedures,
-                            CONFIG.delta_medication_statements,
-                            CONFIG.epsilon,
-                            CONFIG.rounding_step,
-                        )?
-                    } else {
-                        cql_result
-                    }
-                }
-                config::Obfuscate::No => cql_result,
+            let cql_result_new: String = match obfuscate {
+                true => obfuscate_counts_mr(
+                    &cql_result,
+                    obf_cache.lock().await.deref_mut(),
+                    CONFIG.obfuscate_zero,
+                    CONFIG.obfuscate_below_10_mode,
+                    CONFIG.delta_patient,
+                    CONFIG.delta_specimen,
+                    CONFIG.delta_diagnosis,
+                    CONFIG.delta_procedures,
+                    CONFIG.delta_medication_statements,
+                    CONFIG.epsilon,
+                    CONFIG.rounding_step,
+                )?,
+                false => cql_result,
             };
 
             if key_exists {
                 report_cache.lock().await.cache.insert(
-                    encoded_query.to_string(),
+                    (encoded_query.to_string(), obfuscate),
                     (cql_result_new.clone(), std::time::SystemTime::now()),
                 );
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,11 +9,14 @@ mod graceful_shutdown;
 mod logger;
 
 mod intermediate_rep;
+mod task_processing;
 mod util;
 
+use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
 use beam_lib::{TaskRequest, TaskResult, MsgId};
 use laplace_rs::ObfCache;
 use tokio::sync::Mutex;
+use task_processing::TaskQueue;
 
 use crate::util::{is_cql_tampered_with, obfuscate_counts_mr};
 use crate::{config::CONFIG, errors::FocusError};
@@ -27,11 +30,7 @@ use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 use std::{process::exit, time::Duration};
 
-use base64::{engine::general_purpose, Engine as _};
-
 use serde::{Deserialize, Serialize};
-use serde_json::from_slice;
-
 use tracing::{debug, error, warn};
 
 // result cache
@@ -40,7 +39,6 @@ type Report = String;
 type Created = std::time::SystemTime; //epoch
 type BeamTask = TaskRequest<String>;
 type BeamResult = TaskResult<beam_lib::RawString>;
-type Shared<T> = Arc<Mutex<T>>;
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
 struct Metadata {
@@ -77,13 +75,8 @@ pub async fn main() -> ExitCode {
 }
 
 async fn main_loop() -> ExitCode {
-    let obf_cache = Arc::new(Mutex::new(ObfCache {
-        cache: HashMap::new(),
-    }));
-
-    let report_cache: Shared<ReportCache> = Default::default();
-    let mut seen_tasks = Default::default();
-
+    // TODO: The report cache init should be an fn on the cache
+    let mut report_cache: ReportCache = Default::default();
     if let Some(filename) = CONFIG.queries_to_cache_file_path.clone() {
         let lines = util::read_lines(filename.clone().to_string());
         match lines {
@@ -93,7 +86,7 @@ async fn main_loop() -> ExitCode {
                         warn!("A line in the file {} is not readable", filename);
                         continue;
                     };
-                    report_cache.lock().await.cache.insert(ok_line, ("".into(), UNIX_EPOCH));
+                    report_cache.cache.insert(ok_line, ("".into(), UNIX_EPOCH));
                 }
             }
             Err(_) => {
@@ -103,6 +96,8 @@ async fn main_loop() -> ExitCode {
         }
     }
 
+    let mut seen_tasks = Default::default();
+    let mut task_queue = task_processing::spawn_task_workers(report_cache);
     let mut failures = 0;
     while failures < CONFIG.retry_count {
         if failures > 0 {
@@ -125,7 +120,7 @@ async fn main_loop() -> ExitCode {
             //TODO health check
         }
 
-        if let Err(e) = process_tasks(obf_cache.clone(),  report_cache.clone(), &mut seen_tasks).await {
+        if let Err(e) = process_tasks(&mut task_queue, &mut seen_tasks).await {
             warn!("Encountered the following error, while processing tasks: {e}");
             //failures += 1;
         } else {
@@ -139,73 +134,9 @@ async fn main_loop() -> ExitCode {
     ExitCode::from(22)
 }
 
-async fn process_task(
-    task: &BeamTask,
-    obf_cache: Shared<ObfCache>,
-    report_cache: Shared<ReportCache>,
-) -> Result<BeamResult, FocusError> {
-    debug!("Processing task {}", task.id);
-
-    let metadata: Metadata = serde_json::from_value(task.metadata.clone()).unwrap_or(Metadata {
-        project: "default_obfuscation".to_string(),
-        execute: true,
-    });
-
-    if metadata.project == "exporter" {
-        let body = &task.body;
-        return Ok(run_exporter_query(task, body, metadata.execute).await)?;
-    }
-
-    if CONFIG.endpoint_type == config::EndpointType::Blaze {
-        let query = parse_blaze_query(task)?;
-        if query.lang == "cql" {
-            // TODO: Change query.lang to an enum
-
-            Ok(run_cql_query(task, &query, obf_cache, report_cache, metadata.project).await)?
-        } else {
-            warn!("Can't run queries with language {} in Blaze", query.lang);
-            Ok(beam::beam_result::perm_failed(
-                CONFIG.beam_app_id_long.clone(),
-                vec![task.from.clone()],
-                task.id,
-                format!(
-                    "Can't run queries with language {} and/or endpoint type {}",
-                    query.lang, CONFIG.endpoint_type
-                ),
-            ))
-        }
-    } else if CONFIG.endpoint_type == config::EndpointType::Omop {
-        let decoded = decode_body(task)?;
-        let intermediate_rep_query: intermediate_rep::IntermediateRepQuery =
-            from_slice(&decoded).map_err(|e| FocusError::ParsingError(e.to_string()))?;
-        //TODO check that the language is ast
-        let query_decoded = general_purpose::STANDARD
-            .decode(intermediate_rep_query.query)
-            .map_err(FocusError::DecodeError)?;
-        let ast: ast::Ast =
-            from_slice(&query_decoded).map_err(|e| FocusError::ParsingError(e.to_string()))?;
-
-        Ok(run_intermediate_rep_query(task, ast).await)?
-    } else {
-        warn!(
-            "Can't run queries with endpoint type {}",
-            CONFIG.endpoint_type
-        );
-        Ok(beam::beam_result::perm_failed(
-            CONFIG.beam_app_id_long.clone(),
-            vec![task.from.clone()],
-            task.id,
-            format!(
-                "Can't run queries with endpoint type {}",
-                CONFIG.endpoint_type
-            ),
-        ))
-    }
-}
 
 async fn process_tasks(
-    obf_cache: Shared<ObfCache>,
-    report_cache: Shared<ReportCache>,
+    task_queue: &mut TaskQueue,
     seen: &mut HashSet<MsgId>,
 ) -> Result<(), FocusError> {
     debug!("Start processing tasks...");
@@ -216,88 +147,17 @@ async fn process_tasks(
             continue;
         }
         seen.insert(task.id);
-        let local_report_cache = report_cache.clone();
-        let local_obf_cache = obf_cache.clone();
-        tokio::spawn(handle_beam_task(task, local_obf_cache, local_report_cache));
+        task_queue.send(task).await.expect("Receiver is never dropped");
     }
     Ok(())
 }
 
-async fn handle_beam_task(task: TaskRequest<String>, local_obf_cache: Shared<ObfCache>, local_report_cache: Shared<ReportCache>) {
-    let task_cloned = task.clone();
-    let claiming = tokio::task::spawn(async move { beam::claim_task(&task_cloned).await });
-    let res = process_task(&task, local_obf_cache, local_report_cache).await;
-    let error_msg = match res {
-        Err(FocusError::DecodeError(_)) | Err(FocusError::ParsingError(_)) => {
-            Some("Cannot parse query".to_string())
-        }
-        Err(FocusError::LaplaceError(_)) => Some("Cannot obfuscate result".to_string()),
-        Err(ref e) => Some(format!("Cannot execute query: {}", e)),
-        Ok(_) => None,
-    };
-
-    let res = res.ok();
-    // Make sure that claiming the task is done before we update it again.
-    match claiming.await.unwrap() {
-        Ok(_) => {}
-        Err(FocusError::ConfigurationError(s)) => {
-            error!("FATAL: Unable to report back to Beam due to a configuration issue: {s}");
-        }
-        Err(FocusError::UnableToAnswerTask(e)) => {
-            warn!("Unable to report claimed task to Beam: {e}");
-        }
-        Err(e) => {
-            warn!("Unknown error reporting claimed task back to Beam: {e}");
-        }
-    }
-
-    const MAX_TRIES: u32 = 3600;
-    for attempt in 0..MAX_TRIES {
-        let comm_result = if let Some(ref err_msg) = error_msg {
-            beam::fail_task(&task, err_msg).await
-        } else {
-            beam::answer_task(task.id, res.as_ref().unwrap()).await
-        };
-        match comm_result {
-            Ok(_) => break,
-            Err(FocusError::ConfigurationError(s)) => {
-                error!(
-                    "FATAL: Unable to report back to Beam due to a configuration issue: {s}"
-                );
-            }
-            Err(FocusError::UnableToAnswerTask(e)) => {
-                warn!("Unable to report task result to Beam: {e}. Retrying (attempt {attempt}/{MAX_TRIES}).");
-            }
-            Err(e) => {
-                warn!("Unknown error reporting task result back to Beam: {e}. Retrying (attempt {attempt}/{MAX_TRIES}).");
-            }
-        };
-        tokio::time::sleep(Duration::from_secs(2)).await;
-    }
-}
-
-fn decode_body(task: &BeamTask) -> Result<Vec<u8>, FocusError> {
-    let decoded = general_purpose::STANDARD
-        .decode(&task.body)
-        .map_err(FocusError::DecodeError)?;
-
-    Ok(decoded)
-}
-
-fn parse_blaze_query(task: &BeamTask) -> Result<blaze::CqlQuery, FocusError> {
-    let decoded = decode_body(task)?;
-
-    let query: blaze::CqlQuery =
-        from_slice(&decoded).map_err(|e| FocusError::ParsingError(e.to_string()))?;
-
-    Ok(query)
-}
 
 async fn run_cql_query(
     task: &BeamTask,
     query: &CqlQuery,
-    obf_cache: Shared<ObfCache>,
-    report_cache: Shared<ReportCache>,
+    obf_cache: Arc<Mutex<ObfCache>>,
+    report_cache: Arc<Mutex<ReportCache>>,
     project: String,
 ) -> Result<BeamResult, FocusError> {
     let encoded_query =
@@ -443,9 +303,7 @@ fn replace_cql_library(mut query: CqlQuery) -> Result<CqlQuery, FocusError> {
             query.lib
         )))?;
 
-    let decoded_cql = general_purpose::STANDARD
-        .decode(old_data_string)
-        .map_err(FocusError::DecodeError)?;
+    let decoded_cql = util::base64_decode(old_data_string)?;
 
     let decoded_string = str::from_utf8(&decoded_cql)
         .map_err(|_| FocusError::ParsingError("CQL query was invalid".into()))?;
@@ -461,7 +319,7 @@ fn replace_cql_library(mut query: CqlQuery) -> Result<CqlQuery, FocusError> {
     };
 
     let replaced_cql_str = util::replace_cql(decoded_string);
-    let replaced_cql_str_base64 = general_purpose::STANDARD.encode(replaced_cql_str);
+    let replaced_cql_str_base64 = BASE64.encode(replaced_cql_str);
     let new_data_value = serde_json::to_value(replaced_cql_str_base64)
         .expect("unable to turn base64 string into json value - this should not happen");
 
@@ -472,7 +330,7 @@ fn replace_cql_library(mut query: CqlQuery) -> Result<CqlQuery, FocusError> {
 }
 
 fn beam_result(task: BeamTask, measure_report: String) -> Result<BeamResult, FocusError> {
-    let data = general_purpose::STANDARD.encode(measure_report.as_bytes());
+    let data = BASE64.encode(measure_report.as_bytes());
     Ok(beam::beam_result::succeeded(
         CONFIG.beam_app_id_long.clone(),
         vec![task.from],
@@ -481,6 +339,7 @@ fn beam_result(task: BeamTask, measure_report: String) -> Result<BeamResult, Foc
     ))
 }
 
+#[cfg(test)]
 mod test {
     use super::*;
 

--- a/src/task_processing.rs
+++ b/src/task_processing.rs
@@ -1,0 +1,155 @@
+use std::{sync::Arc, collections::HashMap, time::Duration};
+
+use base64::{engine::general_purpose, Engine as _};
+use laplace_rs::ObfCache;
+use tokio::sync::{mpsc, Semaphore, Mutex};
+use tracing::{error, warn, debug};
+
+use crate::{ReportCache, errors::FocusError, beam, BeamTask, BeamResult, run_exporter_query, config::{EndpointType, CONFIG}, run_cql_query, intermediate_rep, ast, run_intermediate_rep_query, Metadata, blaze::parse_blaze_query, util};
+
+const NUM_WORKERS: usize = 3;
+const WORKER_BUFFER: usize = 32;
+
+pub type TaskQueue = mpsc::Sender<BeamTask>;
+
+pub fn spawn_task_workers(report_cache: ReportCache) -> TaskQueue {
+    let (tx, mut rx) = mpsc::channel(WORKER_BUFFER);
+
+    let obf_cache = Arc::new(Mutex::new(ObfCache {
+        cache: HashMap::new(),
+    }));
+
+    let report_cache: Arc<Mutex<ReportCache>> = Arc::new(Mutex::new(report_cache));
+    
+    tokio::spawn(async move {
+        let semaphore = Arc::new(Semaphore::new(NUM_WORKERS));
+        while let Some(task) = rx.recv().await {
+            let permit = semaphore.clone().acquire_owned().await.unwrap();
+            let local_report_cache = report_cache.clone();
+            let local_obf_cache = obf_cache.clone();
+            tokio::spawn(async move {
+                handle_beam_task(task, local_obf_cache, local_report_cache).await;
+                drop(permit)
+            });
+        }
+    });
+
+    tx
+}
+
+async fn handle_beam_task(task: BeamTask, local_obf_cache: Arc<Mutex<ObfCache>>, local_report_cache: Arc<Mutex<ReportCache>>) {
+    let task_cloned = task.clone();
+    let claiming = tokio::task::spawn(async move { beam::claim_task(&task_cloned).await });
+    let res = process_task(&task, local_obf_cache, local_report_cache).await;
+    let error_msg = match res {
+        Err(FocusError::DecodeError(_)) | Err(FocusError::ParsingError(_)) => {
+            Some("Cannot parse query".to_string())
+        }
+        Err(FocusError::LaplaceError(_)) => Some("Cannot obfuscate result".to_string()),
+        Err(ref e) => Some(format!("Cannot execute query: {}", e)),
+        Ok(_) => None,
+    };
+
+    let res = res.ok();
+    // Make sure that claiming the task is done before we update it again.
+    match claiming.await.unwrap() {
+        Ok(_) => {}
+        Err(FocusError::ConfigurationError(s)) => {
+            error!("FATAL: Unable to report back to Beam due to a configuration issue: {s}");
+        }
+        Err(FocusError::UnableToAnswerTask(e)) => {
+            warn!("Unable to report claimed task to Beam: {e}");
+        }
+        Err(e) => {
+            warn!("Unknown error reporting claimed task back to Beam: {e}");
+        }
+    }
+
+    const MAX_TRIES: u32 = 3600;
+    for attempt in 0..MAX_TRIES {
+        let comm_result = if let Some(ref err_msg) = error_msg {
+            beam::fail_task(&task, err_msg).await
+        } else {
+            beam::answer_task(task.id, res.as_ref().unwrap()).await
+        };
+        match comm_result {
+            Ok(_) => break,
+            Err(FocusError::ConfigurationError(s)) => {
+                error!(
+                    "FATAL: Unable to report back to Beam due to a configuration issue: {s}"
+                );
+            }
+            Err(FocusError::UnableToAnswerTask(e)) => {
+                warn!("Unable to report task result to Beam: {e}. Retrying (attempt {attempt}/{MAX_TRIES}).");
+            }
+            Err(e) => {
+                warn!("Unknown error reporting task result back to Beam: {e}. Retrying (attempt {attempt}/{MAX_TRIES}).");
+            }
+        };
+        tokio::time::sleep(Duration::from_secs(2)).await;
+    }
+}
+
+async fn process_task(
+    task: &BeamTask,
+    obf_cache: Arc<Mutex<ObfCache>>,
+    report_cache: Arc<Mutex<ReportCache>>,
+) -> Result<BeamResult, FocusError> {
+    debug!("Processing task {}", task.id);
+
+    let metadata: Metadata = serde_json::from_value(task.metadata.clone()).unwrap_or(Metadata {
+        project: "default_obfuscation".to_string(),
+        execute: true,
+    });
+
+    if metadata.project == "exporter" {
+        let body = &task.body;
+        return Ok(run_exporter_query(task, body, metadata.execute).await)?;
+    }
+
+    if CONFIG.endpoint_type == EndpointType::Blaze {
+        let query = parse_blaze_query(task)?;
+        if query.lang == "cql" {
+            // TODO: Change query.lang to an enum
+
+            Ok(run_cql_query(task, &query, obf_cache, report_cache, metadata.project).await)?
+        } else {
+            warn!("Can't run queries with language {} in Blaze", query.lang);
+            Ok(beam::beam_result::perm_failed(
+                CONFIG.beam_app_id_long.clone(),
+                vec![task.from.clone()],
+                task.id,
+                format!(
+                    "Can't run queries with language {} and/or endpoint type {}",
+                    query.lang, CONFIG.endpoint_type
+                ),
+            ))
+        }
+    } else if CONFIG.endpoint_type == EndpointType::Omop {
+        let decoded = util::base64_decode(&task.body)?;
+        let intermediate_rep_query: intermediate_rep::IntermediateRepQuery =
+            serde_json::from_slice(&decoded).map_err(|e| FocusError::ParsingError(e.to_string()))?;
+        //TODO check that the language is ast
+        let query_decoded = general_purpose::STANDARD
+            .decode(intermediate_rep_query.query)
+            .map_err(FocusError::DecodeError)?;
+        let ast: ast::Ast =
+            serde_json::from_slice(&query_decoded).map_err(|e| FocusError::ParsingError(e.to_string()))?;
+
+        Ok(run_intermediate_rep_query(task, ast).await)?
+    } else {
+        warn!(
+            "Can't run queries with endpoint type {}",
+            CONFIG.endpoint_type
+        );
+        Ok(beam::beam_result::perm_failed(
+            CONFIG.beam_app_id_long.clone(),
+            vec![task.from.clone()],
+            task.id,
+            format!(
+                "Can't run queries with endpoint type {}",
+                CONFIG.endpoint_type
+            ),
+        ))
+    }
+}

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,4 +1,6 @@
 use crate::errors::FocusError;
+use base64::Engine as _;
+use base64::engine::general_purpose;
 use laplace_rs::{get_from_cache_or_privatize, Bin, ObfCache, ObfuscateBelow10Mode};
 use rand::thread_rng;
 use serde::{Deserialize, Serialize};
@@ -79,6 +81,12 @@ pub(crate) fn read_lines(filename: String) -> Result<io::Lines<BufReader<File>>,
         FocusError::FileOpeningError(format!("Cannot open file {}: {} ", filename, e))
     })?;
     Ok(io::BufReader::new(file).lines())
+}
+
+pub(crate) fn base64_decode(data: impl AsRef<[u8]>) -> Result<Vec<u8>, FocusError> {
+    general_purpose::STANDARD
+        .decode(data)
+        .map_err(FocusError::DecodeError)
 }
 
 // REPLACE_MAP is built in build.rs


### PR DESCRIPTION
I have not tested this yet.

Doing this asynchronously with beam is also kind of difficult as we might get the same task again because the claiming is not done before we ask for the next one. So this PR will probably lead to the beam proxy being spammed by focus while we are claiming a task.

I want to implement a task streaming interface in beam which will prevent us from having this kind of issue but I have not gotten the time to do it.