### PR TITLE
Bugfix: the CQL extension should prevent the sorting of null objects

### DIFF
--- a/resources/cql/DKTK_STRAT_AGE_STRATIFIER
+++ b/resources/cql/DKTK_STRAT_AGE_STRATIFIER
@@ -1,7 +1,7 @@
 define PrimaryDiagnosis:
 First(
 from [Condition] C
-where C.extension.where(url='http://hl7.org/fhir/StructureDefinition/condition-related').empty()
+where C.extension.where(url='http://hl7.org/fhir/StructureDefinition/condition-related').empty() and C.onset is not null
 sort by date from onset asc)
 
 define AgeClass:


### PR DESCRIPTION
The CQL extension should prevent the sorting of null objects. 
I hope that this can solve the problem (with AgeCalss) in Essen.