### PR TITLE
Fix Histology typo

### DIFF
--- a/resources/cql/DKTK_STRAT_HISTOLOGY_STRATIFIER
+++ b/resources/cql/DKTK_STRAT_HISTOLOGY_STRATIFIER
@@ -1,5 +1,5 @@
 define Histo:
 if InInitialPopulation then [Observation] else {} as List <Observation>
 
-define function Histlogoy(histo FHIR.Observation):
+define function Histology(histo FHIR.Observation):
  if histo.code.coding.where(code = '59847-4').code.first() is null then 0 else 1

--- a/src/util.rs
+++ b/src/util.rs
@@ -474,7 +474,7 @@ mod test {
         assert_eq!(replace_cql(decoded_library), expected_result);
 
         let decoded_library = "DKTK_STRAT_HISTOLOGY_STRATIFIER";
-        let expected_result = "define Histo:\nif InInitialPopulation then [Observation] else {} as List <Observation>\n\ndefine function Histlogoy(histo FHIR.Observation):\n if histo.code.coding.where(code = '59847-4').code.first() is null then 0 else 1\n";
+        let expected_result = "define Histo:\nif InInitialPopulation then [Observation] else {} as List <Observation>\n\ndefine function Histology(histo FHIR.Observation):\n if histo.code.coding.where(code = '59847-4').code.first() is null then 0 else 1\n";
         assert_eq!(replace_cql(decoded_library), expected_result);
 
         let decoded_library = "INVALID_KEY";


### PR DESCRIPTION
This fixes a typo in histologies and requires three pull requests to work:
- https://github.com/samply/lens/pull/85
- https://github.com/samply/focus/pull/130
- https://github.com/samply/prism/pull/16