### PR TITLE
fix: change entrypoint of image to focus

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,5 +15,4 @@ RUN chmod +x /app/*
 FROM gcr.io/distroless/cc-debian12
 ARG COMPONENT
 COPY --from=chmodder /app/$COMPONENT /usr/local/bin/samply
-ENTRYPOINT [ "/usr/local/bin/samply" ]
-
+ENTRYPOINT [ "/usr/local/bin/focus" ]


### PR DESCRIPTION
This should solve the issues with building the Docker Image. Please make sure that the Image is still working.