### PR TITLE
empty features

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,7 +17,7 @@ jobs:
       #architectures: '[ "amd64", "arm64" ]'
       #profile: debug
       test-via-script: false
-      features: '[ "bbmri", "dktk" ]'
+      features: '[ "bbmri", "dktk", "" ]'
       push-to: ${{ (github.ref_protected == true || github.event_name == 'workflow_dispatch') && 'dockerhub' || 'ghcr' }}
     secrets:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}


### PR DESCRIPTION
so that we also get an image without either bbmri or dktk features
for projects such as eucaim, and to avoid breaking changes in BHs while Lens is still sending CQL with placeholders and not AST