### PR TITLE
Modify DKTK_Strat_SPECIMEN to improve the search more sample centric

### DIFF
--- a/resources/cql/DKTK_REPLACE_HISTOLOGY_STRATIFIER
+++ b/resources/cql/DKTK_REPLACE_HISTOLOGY_STRATIFIER
@@ -1,0 +1,4 @@
+define Histo:
+if InInitialPopulation then [Observation] else {} as List <Observation>
+
+define function Histology(histo FHIR.Observation):

--- a/resources/cql/DKTK_REPLACE_SPECIMEN_STRATIFIER
+++ b/resources/cql/DKTK_REPLACE_SPECIMEN_STRATIFIER
@@ -1,0 +1,4 @@
+define function SampleType(specimen FHIR.Specimen):
+specimen.type.coding.where(system = 'https://fhir.bbmri.de/CodeSystem/SampleMaterialType').code.first()
+
+define Specimen:

--- a/resources/cql/DKTK_STRAT_SPECIMEN_STRATIFIER
+++ b/resources/cql/DKTK_STRAT_SPECIMEN_STRATIFIER
@@ -1,4 +1,5 @@
+define Specimen:
+if InInitialPopulation then [Specimen] else {} as List<Specimen>
+
 define function SampleType(specimen FHIR.Specimen):
 specimen.type.coding.where(system = 'https://fhir.bbmri.de/CodeSystem/SampleMaterialType').code.first()
-
-define Specimen:

--- a/resources/cql/DKTK_STRAT_SPECIMEN_STRATIFIER
+++ b/resources/cql/DKTK_STRAT_SPECIMEN_STRATIFIER
@@ -1,5 +1,4 @@
-define Specimen:
-if InInitialPopulation then [Specimen] else {} as List<Specimen>
-
 define function SampleType(specimen FHIR.Specimen):
 specimen.type.coding.where(system = 'https://fhir.bbmri.de/CodeSystem/SampleMaterialType').code.first()
+
+define Specimen:


### PR DESCRIPTION
This PR introduces a new stratifier for DKTK sample-specific search, while keeping the existing stratifier intact to ensure backwards compatibility.

This feature needs to be merged in Lens as well, with PR https://github.com/samply/lens/pull/163.

This was tested locally with a lens+spot+beam+focus+blaze setup and with our test server.

