### PR TITLE
chore: allow `Zlib` license

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -82,6 +82,7 @@ allow = [
     "BSD-3-Clause",
     "Unicode-DFS-2016",
     "Unicode-3.0",
+    "Zlib",
     #"Apache-2.0 WITH LLVM-exception",
 ]
 # List of explicitly disallowed licenses


### PR DESCRIPTION
CI is failing in #195 and #163 due to the license change of some transitive dependency