### PR TITLE
workaround for messed up AST

### DIFF
--- a/src/cql.rs
+++ b/src/cql.rs
@@ -70,7 +70,7 @@ fn generate_cql(ast: ast::Ast) -> Result<String, FocusError> {
 
     cql = cql.replace("{{lists}}", lists.as_str());
 
-    if retrieval_criteria.is_empty() {
+    if retrieval_criteria.is_empty() || retrieval_criteria=="()" {
         cql = cql.replace("{{retrieval_criteria}}", "true"); //()?
     } else {
         let formatted_retrieval_criteria = format!("({})", retrieval_criteria);


### PR DESCRIPTION
Temporary fix for messed up AST new Lens sends for empty query, because I have no idea and no way to check right now what gets sent when the query is not empty