### PR TITLE
fix: disallow unknown stratifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,18 @@
+# Samply.Focus v0.15.3 2025-09-22
+
+* Security fix: Reject unknown stratifiers in obfuscation
+
 # Samply.Focus v0.15.2 2025-09-19
+
+## Major changes
+
+* Support SQL translation for EUCAIM's CDM
 
 ## Minor changes
 
 * Update organoid dashboard internal query
 * Add DHKI age stratifier
-* Disallow CQL in BBMRI
+* Security fix: Disallow CQL as input for BBMRI queries; only allow AST queries
 
 # Samply.Focus v0.15.1 2025-08-14
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -197,8 +197,11 @@ pub fn obfuscate_counts_mr(
                     rounding_step,
                 )?;
             }
-            _ => {
-                warn!("Focus is not aware of {} type of stratifier, therefore it will not obfuscate the values.", &g.code.text[..])
+            strat => {
+                warn!("Focus is not aware of {strat} type of stratifier, therefore it will not obfuscate the values.");
+                return Err(FocusError::CQLTemperedWithError(
+                    "Unknown stratifier".to_string(),
+                ));
             }
         }
     }


### PR DESCRIPTION
The error does not get to lens as we call `FocusError::user_facing_error` before sending it.