### PR TITLE
Add MIABIS-on-FHIR 1.0.0 project support

### DIFF
--- a/dev/test_miabis_e2e.sh
+++ b/dev/test_miabis_e2e.sh
@@ -1,0 +1,269 @@
+#!/usr/bin/env bash
+# dev/test_miabis_e2e.sh — End-to-end integration test for the miabis project.
+#
+# Spins up a local Blaze instance, loads a minimal MIABIS-on-FHIR 1.0.0
+# test bundle, starts a mock Beam proxy, and runs focus against it.
+# Verifies that the returned MeasureReport contains the expected counts.
+#
+# Prerequisites:
+#   - Docker (with the compose plugin)
+#   - Python 3
+#   - focus binary: built via `cargo build` (or `cargo build --release`)
+#
+# Usage:
+#   dev/test_miabis_e2e.sh [path/to/focus/binary]
+#
+# If no binary path is given the script looks for:
+#   ./target/debug/focus  ./target/release/focus
+#
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+BLAZE_PORT=18080
+BLAZE_URL="http://localhost:${BLAZE_PORT}/fhir"
+PROXY_PORT=18082
+FOCUS_APP_ID="focus.proxy1.broker.samply.de"
+BUNDLE="${REPO_ROOT}/resources/test/miabis_e2e_bundle.json"
+
+RESULT_FILE="$(mktemp /tmp/miabis_e2e_result_XXXXXX.json)"
+PROXY_PY="$(mktemp /tmp/miabis_e2e_proxy_XXXXXX.py)"
+PASS=0
+
+cleanup() {
+    kill "$FOCUS_PID" 2>/dev/null || true
+    wait "$FOCUS_PID" 2>/dev/null || true
+    kill "$PROXY_PID" 2>/dev/null || true
+    wait "$PROXY_PID" 2>/dev/null || true
+    docker rm -f miabis-e2e-blaze 2>/dev/null || true
+    rm -f "$RESULT_FILE" "$PROXY_PY"
+}
+trap cleanup EXIT
+
+# ── 1. Locate focus binary ────────────────────────────────────────────────────
+if [[ -n "${1:-}" ]]; then
+    FOCUS_BIN="$1"
+elif [[ -x "${REPO_ROOT}/target/debug/focus" ]]; then
+    FOCUS_BIN="${REPO_ROOT}/target/debug/focus"
+elif [[ -x "${REPO_ROOT}/target/release/focus" ]]; then
+    FOCUS_BIN="${REPO_ROOT}/target/release/focus"
+else
+    echo "ERROR: focus binary not found. Run 'cargo build' first, or pass the path as an argument." >&2
+    exit 1
+fi
+
+echo "==> Using focus binary: ${FOCUS_BIN}"
+
+# ── 2. Check prerequisites ────────────────────────────────────────────────────
+for cmd in docker python3 curl; do
+    command -v "$cmd" >/dev/null 2>&1 || { echo "ERROR: $cmd not found in PATH" >&2; exit 1; }
+done
+
+# ── 3. Start Blaze ────────────────────────────────────────────────────────────
+echo "==> Starting Blaze on port ${BLAZE_PORT}..."
+docker run -d --rm \
+    --name miabis-e2e-blaze \
+    -p "${BLAZE_PORT}:8080" \
+    -e JAVA_TOOL_OPTIONS="-Xmx512m" \
+    samply/blaze:latest >/dev/null
+
+echo -n "==> Waiting for Blaze..."
+for i in $(seq 1 60); do
+    curl -sf "${BLAZE_URL}/metadata" >/dev/null 2>&1 && break
+    printf '.'; sleep 2
+done
+echo " ready."
+
+# ── 4. Load test bundle ───────────────────────────────────────────────────────
+echo "==> Loading MIABIS test bundle..."
+LOAD_RESULT=$(curl -sf -X POST "${BLAZE_URL}" \
+    -H "Content-Type: application/fhir+json" \
+    -d "@${BUNDLE}")
+ENTRY_COUNT=$(echo "$LOAD_RESULT" | python3 -c "
+import sys, json
+r = json.load(sys.stdin)
+print(len(r.get('entry', [])))
+")
+echo "    Loaded ${ENTRY_COUNT} resources (2 Patient, 2 Condition, 3 Specimen expected)"
+
+# ── 5. Build AST task payload (empty AND = all patients) ──────────────────────
+AST_JSON='{"ast":{"operand":"AND","children":[]},"id":"a6f1ccf3-ebf1-424f-9d69-4e5d135f2340"}'
+AST_B64=$(echo -n "$AST_JSON" | base64 -w0)
+BODY_JSON="{\"lang\":\"ast\",\"payload\":\"${AST_B64}\"}"
+BODY_B64=$(echo -n "$BODY_JSON" | base64 -w0)
+TASK_ID="$(python3 -c 'import uuid; print(uuid.uuid4())')"
+
+# ── 6. Write and start mock Beam proxy ────────────────────────────────────────
+cat > "$PROXY_PY" <<PYEOF
+import base64, json, os, threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+TASK_ID   = "${TASK_ID}"
+FOCUS_APP = "${FOCUS_APP_ID}"
+BODY_B64  = "${BODY_B64}"
+RESULT_FILE = "${RESULT_FILE}"
+PORT      = ${PROXY_PORT}
+
+TASK = {
+    "id": TASK_ID, "from": "mock-broker.local.test", "to": [FOCUS_APP],
+    "ttl": "3600s",
+    "failure_strategy": {"retry": {"backoff_millisecs": 1000, "max_tries": 3}},
+    "metadata": {"project": "miabis"},
+    "body": BODY_B64,
+}
+task_served = False
+result_done = threading.Event()
+
+class Handler(BaseHTTPRequestHandler):
+    def log_message(self, fmt, *args): pass
+    def send_json(self, code, data):
+        body = json.dumps(data).encode()
+        self.send_response(code)
+        self.send_header('Content-Type', 'application/json')
+        self.send_header('Content-Length', str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+    def do_GET(self):
+        global task_served
+        if self.path.startswith('/v1/tasks'):
+            if not task_served:
+                task_served = True
+                self.send_json(200, [TASK])
+            else:
+                self.send_json(200, [])
+        elif self.path == '/v1/health':
+            self.send_json(200, {'status': 'ok'})
+        else:
+            self.send_json(404, {})
+    def do_PUT(self):
+        parts = self.path.strip('/').split('/')
+        if len(parts) == 5 and parts[0]=='v1' and parts[1]=='tasks' and parts[3]=='results':
+            self._handle_result()
+        else:
+            self.send_json(404, {})
+    def do_POST(self): self.do_PUT()
+    def _handle_result(self):
+        length = int(self.headers.get('Content-Length', 0))
+        raw = self.rfile.read(length)
+        try:
+            env = json.loads(raw)
+            if env.get('status') == 'claimed':
+                self.send_json(201, {})
+                return
+            decoded = base64.b64decode(env.get('body', '')).decode()
+            with open(RESULT_FILE, 'w') as f:
+                f.write(decoded)
+        except Exception:
+            pass
+        self.send_json(201, {})
+        result_done.set()
+
+server = HTTPServer(('0.0.0.0', PORT), Handler)
+t = threading.Thread(target=server.serve_forever, daemon=True)
+t.start()
+result_done.wait(timeout=120)
+threading.Event().wait(timeout=2)
+server.shutdown()
+PYEOF
+
+echo "==> Starting mock Beam proxy on port ${PROXY_PORT}..."
+python3 "$PROXY_PY" &
+PROXY_PID=$!
+sleep 1
+
+# ── 7. Run focus ──────────────────────────────────────────────────────────────
+echo "==> Running focus..."
+BEAM_PROXY_URL="http://localhost:${PROXY_PORT}" \
+BEAM_APP_ID_LONG="${FOCUS_APP_ID}" \
+API_KEY="test" \
+ENDPOINT_URL="${BLAZE_URL}/" \
+OBFUSCATE="no" \
+ENDPOINT_TYPE="blaze" \
+RUST_LOG="warn" \
+"${FOCUS_BIN}" &
+FOCUS_PID=$!
+
+wait "$PROXY_PID" || true
+kill "$FOCUS_PID" 2>/dev/null || true
+wait "$FOCUS_PID" 2>/dev/null || true
+
+# ── 8. Verify MeasureReport ───────────────────────────────────────────────────
+echo "==> Verifying MeasureReport..."
+python3 - <<PYEOF
+import json, sys
+
+with open("${RESULT_FILE}") as f:
+    report = json.load(f)
+
+if report.get('resourceType') == 'OperationOutcome':
+    for issue in report.get('issue', []):
+        print(f"  ERROR: {issue.get('diagnostics', '?')}")
+    sys.exit(1)
+
+failures = []
+
+def pop(group):
+    return (group.get('population') or [{}])[0].get('count', -1)
+
+def stratum_map(group, stratifier_text):
+    for strat in group.get('stratifier', []):
+        codes = strat.get('code') or []
+        if any(c.get('text') == stratifier_text for c in codes):
+            return {s['value']['text']: (s.get('population') or [{}])[0].get('count', 0)
+                    for s in strat.get('stratum', []) if 'value' in s}
+    return {}
+
+groups = {g['code']['text']: g for g in report.get('group', [])}
+
+# Expected counts derived from resources/test/miabis_e2e_bundle.json
+checks = [
+    # (description, actual, expected)
+    ("patient population",   pop(groups['patient']),   2),
+    ("diagnosis population", pop(groups['diagnosis']), 2),
+    ("specimen population",  pop(groups['specimen']),  3),
+]
+
+gender = stratum_map(groups['patient'], 'gender')
+checks += [
+    ("gender female", gender.get('female', 0), 1),
+    ("gender male",   gender.get('male', 0),   1),
+]
+
+diag = stratum_map(groups['diagnosis'], 'diagnosis')
+checks += [
+    ("diagnosis C34", diag.get('C34', 0), 1),
+    ("diagnosis C18", diag.get('C18', 0), 1),
+]
+
+sample = stratum_map(groups['specimen'], 'sample_kind')
+checks += [
+    ("sample_kind blood-plasma",  sample.get('blood-plasma', 0),  1),
+    ("sample_kind tissue-ffpe",   sample.get('tissue-ffpe', 0),   1),
+    ("sample_kind whole-blood",   sample.get('whole-blood', 0),   1),
+]
+
+temp = stratum_map(groups['specimen'], 'storage_temperature')
+checks += [
+    ("storage_temperature LN", temp.get('LN', 0), 2),
+    ("storage_temperature RT", temp.get('RT', 0), 1),
+]
+
+cust = stratum_map(groups['patient'], 'Custodian')
+checks += [
+    ("Custodian collection-test-A", cust.get('collection-test-A', 0), 1),
+    ("Custodian collection-test-B", cust.get('collection-test-B', 0), 1),
+]
+
+for desc, actual, expected in checks:
+    status = "PASS" if actual == expected else "FAIL"
+    print(f"  [{status}] {desc}: {actual} (expected {expected})")
+    if actual != expected:
+        failures.append(desc)
+
+if failures:
+    print(f"\nFAILED: {len(failures)} check(s) did not pass.")
+    sys.exit(1)
+else:
+    print(f"\nAll {len(checks)} checks passed.")
+PYEOF
+
+echo "==> E2E test complete."

--- a/resources/test/miabis_e2e_bundle.json
+++ b/resources/test/miabis_e2e_bundle.json
@@ -1,0 +1,170 @@
+{
+  "resourceType": "Bundle",
+  "type": "transaction",
+  "entry": [
+    {
+      "fullUrl": "Patient/miabis-e2e-p1",
+      "resource": {
+        "resourceType": "Patient",
+        "id": "miabis-e2e-p1",
+        "gender": "female",
+        "birthDate": "1970-03-15"
+      },
+      "request": { "method": "PUT", "url": "Patient/miabis-e2e-p1" }
+    },
+    {
+      "fullUrl": "Patient/miabis-e2e-p2",
+      "resource": {
+        "resourceType": "Patient",
+        "id": "miabis-e2e-p2",
+        "gender": "male",
+        "birthDate": "1955-06-20"
+      },
+      "request": { "method": "PUT", "url": "Patient/miabis-e2e-p2" }
+    },
+    {
+      "fullUrl": "Condition/miabis-e2e-c1",
+      "resource": {
+        "resourceType": "Condition",
+        "id": "miabis-e2e-c1",
+        "subject": { "reference": "Patient/miabis-e2e-p1" },
+        "code": {
+          "coding": [
+            {
+              "system": "http://hl7.org/fhir/sid/icd-10",
+              "code": "C34"
+            }
+          ]
+        },
+        "onsetDateTime": "2015-03-10"
+      },
+      "request": { "method": "PUT", "url": "Condition/miabis-e2e-c1" }
+    },
+    {
+      "fullUrl": "Condition/miabis-e2e-c2",
+      "resource": {
+        "resourceType": "Condition",
+        "id": "miabis-e2e-c2",
+        "subject": { "reference": "Patient/miabis-e2e-p2" },
+        "code": {
+          "coding": [
+            {
+              "system": "http://hl7.org/fhir/sid/icd-10",
+              "code": "C18"
+            }
+          ]
+        },
+        "onsetDateTime": "2010-06-15"
+      },
+      "request": { "method": "PUT", "url": "Condition/miabis-e2e-c2" }
+    },
+    {
+      "fullUrl": "Specimen/miabis-e2e-s1",
+      "resource": {
+        "resourceType": "Specimen",
+        "id": "miabis-e2e-s1",
+        "subject": { "reference": "Patient/miabis-e2e-p1" },
+        "extension": [
+          {
+            "url": "https://fhir.bbmri-eric.eu/StructureDefinition/miabis-sample-collection-extension",
+            "valueIdentifier": { "value": "collection-test-A" }
+          }
+        ],
+        "type": {
+          "coding": [
+            {
+              "system": "https://fhir.bbmri-eric.eu/CodeSystem/miabis-detailed-samply-type-cs",
+              "code": "Plasma"
+            }
+          ]
+        },
+        "processing": [
+          {
+            "extension": [
+              {
+                "url": "https://fhir.bbmri-eric.eu/StructureDefinition/miabis-sample-storage-temperature-extension",
+                "valueCodeableConcept": {
+                  "coding": [ { "code": "LN" } ]
+                }
+              }
+            ]
+          }
+        ],
+        "collection": { "collectedDateTime": "2016-01-20" }
+      },
+      "request": { "method": "PUT", "url": "Specimen/miabis-e2e-s1" }
+    },
+    {
+      "fullUrl": "Specimen/miabis-e2e-s2",
+      "resource": {
+        "resourceType": "Specimen",
+        "id": "miabis-e2e-s2",
+        "subject": { "reference": "Patient/miabis-e2e-p1" },
+        "extension": [
+          {
+            "url": "https://fhir.bbmri-eric.eu/StructureDefinition/miabis-sample-collection-extension",
+            "valueIdentifier": { "value": "collection-test-A" }
+          }
+        ],
+        "type": {
+          "coding": [
+            {
+              "system": "https://fhir.bbmri-eric.eu/CodeSystem/miabis-detailed-samply-type-cs",
+              "code": "TissueFixed"
+            }
+          ]
+        },
+        "processing": [
+          {
+            "extension": [
+              {
+                "url": "https://fhir.bbmri-eric.eu/StructureDefinition/miabis-sample-storage-temperature-extension",
+                "valueCodeableConcept": {
+                  "coding": [ { "code": "RT" } ]
+                }
+              }
+            ]
+          }
+        ],
+        "collection": { "collectedDateTime": "2016-02-15" }
+      },
+      "request": { "method": "PUT", "url": "Specimen/miabis-e2e-s2" }
+    },
+    {
+      "fullUrl": "Specimen/miabis-e2e-s3",
+      "resource": {
+        "resourceType": "Specimen",
+        "id": "miabis-e2e-s3",
+        "subject": { "reference": "Patient/miabis-e2e-p2" },
+        "extension": [
+          {
+            "url": "https://fhir.bbmri-eric.eu/StructureDefinition/miabis-sample-collection-extension",
+            "valueIdentifier": { "value": "collection-test-B" }
+          }
+        ],
+        "type": {
+          "coding": [
+            {
+              "system": "https://fhir.bbmri-eric.eu/CodeSystem/miabis-detailed-samply-type-cs",
+              "code": "WholeBlood"
+            }
+          ]
+        },
+        "processing": [
+          {
+            "extension": [
+              {
+                "url": "https://fhir.bbmri-eric.eu/StructureDefinition/miabis-sample-storage-temperature-extension",
+                "valueCodeableConcept": {
+                  "coding": [ { "code": "LN" } ]
+                }
+              }
+            ]
+          }
+        ],
+        "collection": { "collectedDateTime": "2011-07-01" }
+      },
+      "request": { "method": "PUT", "url": "Specimen/miabis-e2e-s3" }
+    }
+  ]
+}

--- a/src/cql.rs
+++ b/src/cql.rs
@@ -295,21 +295,27 @@ pub fn process(
                     match condition.value {
                         ast::ConditionValue::StringArray(string_array) => {
                             let mut string_array_with_workarounds = string_array.clone();
-                            for value in string_array {
-                                if let Some(additional_values) =
-                                    project.get_sample_type_workarounds().get(value.as_str())
-                                {
-                                    for additional_value in additional_values {
-                                        string_array_with_workarounds
-                                            .push((*additional_value).into());
+                            if condition_key_trans == "sample_kind" {
+                                for value in &string_array_with_workarounds.clone() {
+                                    if let Some(additional_values) =
+                                        project.get_sample_type_workarounds().get(value.as_str())
+                                    {
+                                        for additional_value in additional_values {
+                                            string_array_with_workarounds
+                                                .push((*additional_value).into());
+                                        }
                                     }
                                 }
-                                if let Some(additional_values) =
-                                    project.get_storage_temperature_workarounds().get(value.as_str())
-                                {
-                                    for additional_value in additional_values {
-                                        string_array_with_workarounds
-                                            .push((*additional_value).into());
+                            }
+                            if condition_key_trans == "storage_temperature" {
+                                for value in &string_array_with_workarounds.clone() {
+                                    if let Some(additional_values) =
+                                        project.get_storage_temperature_workarounds().get(value.as_str())
+                                    {
+                                        for additional_value in additional_values {
+                                            string_array_with_workarounds
+                                                .push((*additional_value).into());
+                                        }
                                     }
                                 }
                             }
@@ -354,18 +360,22 @@ pub fn process(
                     ast::ConditionValue::String(string) => {
                         let operator_str = " or ";
                         let mut string_array_with_workarounds = vec![string.clone()];
-                        if let Some(additional_values) =
-                            project.get_sample_type_workarounds().get(string.as_str())
-                        {
-                            for additional_value in additional_values {
-                                string_array_with_workarounds.push((*additional_value).into());
+                        if condition_key_trans == "sample_kind" {
+                            if let Some(additional_values) =
+                                project.get_sample_type_workarounds().get(string.as_str())
+                            {
+                                for additional_value in additional_values {
+                                    string_array_with_workarounds.push((*additional_value).into());
+                                }
                             }
                         }
-                        if let Some(additional_values) =
-                            project.get_storage_temperature_workarounds().get(string.as_str())
-                        {
-                            for additional_value in additional_values {
-                                string_array_with_workarounds.push((*additional_value).into());
+                        if condition_key_trans == "storage_temperature" {
+                            if let Some(additional_values) =
+                                project.get_storage_temperature_workarounds().get(string.as_str())
+                            {
+                                for additional_value in additional_values {
+                                    string_array_with_workarounds.push((*additional_value).into());
+                                }
                             }
                         }
                         let mut condition_humongous_string = "(".to_string();

--- a/src/cql.rs
+++ b/src/cql.rs
@@ -304,6 +304,14 @@ pub fn process(
                                             .push((*additional_value).into());
                                     }
                                 }
+                                if let Some(additional_values) =
+                                    project.get_storage_temperature_workarounds().get(value.as_str())
+                                {
+                                    for additional_value in additional_values {
+                                        string_array_with_workarounds
+                                            .push((*additional_value).into());
+                                    }
+                                }
                             }
                             let mut condition_humongous_string = "(".to_string();
                             let mut filter_humongous_string = "(".to_string();
@@ -348,6 +356,13 @@ pub fn process(
                         let mut string_array_with_workarounds = vec![string.clone()];
                         if let Some(additional_values) =
                             project.get_sample_type_workarounds().get(string.as_str())
+                        {
+                            for additional_value in additional_values {
+                                string_array_with_workarounds.push((*additional_value).into());
+                            }
+                        }
+                        if let Some(additional_values) =
+                            project.get_storage_temperature_workarounds().get(string.as_str())
                         {
                             for additional_value in additional_values {
                                 string_array_with_workarounds.push((*additional_value).into());
@@ -725,107 +740,114 @@ mod test {
     //     pretty_assertions::assert_eq!(false, true);
     // }
 
-    // ── MIABIS-on-FHIR 1.0.0 tests ───────────────────────────────────────────
+    // ── MIABIS-on-FHIR workaround tests ──────────────────────────────────────
+    // These verify that the STORAGE_TEMPERATURE_WORKAROUNDS and
+    // SAMPLE_TYPE_WORKAROUNDS maps are correctly applied when generating CQL
+    // for the MiabisOnFhir project.  The workaround mechanism ORs the MIABIS
+    // code alongside the original Lens code so that MIABIS data (which stores
+    // native MIABIS codes) is still found when Lens sends BBMRI canonical codes.
 
-    const MIABIS_FEMALE: &str = r#"{"ast":{"operand":"OR","children":[{"operand":"AND","children":[{"operand":"OR","children":[{"key":"gender","type":"EQUALS","system":"","value":"female"}]}]}]},"id":"a6f1ccf3-ebf1-424f-9d69-4e5d135f2340"}"#;
+    // storage_temperature: EQUALS "temperatureRoom"  →  also queries "RT"
+    const MIABIS_TEMP_EQUALS_ROOM: &str = r#"{"ast":{"operand":"OR","children":[{"operand":"AND","children":[{"operand":"OR","children":[{"key":"storage_temperature","type":"EQUALS","system":"","value":"temperatureRoom"}]}]}]},"id":"miabis-t1"}"#;
 
-    const MIABIS_DIAGNOSIS_C34: &str = r#"{"ast":{"operand":"OR","children":[{"operand":"AND","children":[{"operand":"OR","children":[{"key":"diagnosis","type":"EQUALS","system":"http://hl7.org/fhir/sid/icd-10","value":"C34"}]}]}]},"id":"a6f1ccf3-ebf1-424f-9d69-4e5d135f2340"}"#;
+    // storage_temperature: EQUALS "four_degrees"  →  also queries "2to10"
+    const MIABIS_TEMP_EQUALS_FOUR: &str = r#"{"ast":{"operand":"OR","children":[{"operand":"AND","children":[{"operand":"OR","children":[{"key":"storage_temperature","type":"EQUALS","system":"","value":"four_degrees"}]}]}]},"id":"miabis-t2"}"#;
 
-    const MIABIS_SAMPLE_KIND_FFPE: &str = r#"{"ast":{"operand":"OR","children":[{"operand":"AND","children":[{"operand":"OR","children":[{"key":"sample_kind","type":"EQUALS","system":"","value":"tissue-ffpe"}]}]}]},"id":"a6f1ccf3-ebf1-424f-9d69-4e5d135f2340"}"#;
+    // storage_temperature: IN ["temperature2to10","temperatureGN"]  →  also "2to10","LN"
+    const MIABIS_TEMP_IN: &str = r#"{"ast":{"operand":"OR","children":[{"operand":"AND","children":[{"operand":"OR","children":[{"key":"storage_temperature","type":"IN","system":"","value":["temperature2to10","temperatureGN"]}]}]}]},"id":"miabis-t3"}"#;
 
-    const MIABIS_STORAGE_TEMP_LN: &str = r#"{"ast":{"operand":"OR","children":[{"operand":"AND","children":[{"operand":"OR","children":[{"key":"storage_temperature","type":"EQUALS","system":"","value":"LN"}]}]}]},"id":"a6f1ccf3-ebf1-424f-9d69-4e5d135f2340"}"#;
+    // storage_temperature: "storage_temperature_uncharted"  →  intentionally unmapped
+    const MIABIS_TEMP_UNCHARTED: &str = r#"{"ast":{"operand":"OR","children":[{"operand":"AND","children":[{"operand":"OR","children":[{"key":"storage_temperature","type":"EQUALS","system":"","value":"storage_temperature_uncharted"}]}]}]},"id":"miabis-t4"}"#;
 
-    #[test]
-    fn test_miabis_empty() {
-        // An empty query must always declare both mandatory code systems so that
-        // SampleType() and DiagnosisCode() in the template can reference them.
-        let cql = generate_cql(serde_json::from_str(EMPTY).unwrap(), Project::MiabisOnFhir)
-            .unwrap();
-        assert!(
-            cql.contains("codesystem icd10: 'http://hl7.org/fhir/sid/icd-10'"),
-            "icd10 codesystem declaration missing"
-        );
-        assert!(
-            cql.contains("codesystem MiabisDetailedSampleType: 'https://fhir.bbmri-eric.eu/CodeSystem/miabis-detailed-samply-type-cs'"),
-            "MiabisDetailedSampleType codesystem declaration missing"
-        );
-        assert!(
-            cql.contains("define InInitialPopulation:\ntrue"),
-            "empty query should match all patients"
-        );
-    }
+    // sample_kind: EQUALS "whole-blood"  →  also queries "WholeBlood"
+    const MIABIS_SAMPLE_EQUALS_WHOLE_BLOOD: &str = r#"{"ast":{"operand":"OR","children":[{"operand":"AND","children":[{"operand":"OR","children":[{"key":"sample_kind","type":"EQUALS","system":"","value":"whole-blood"}]}]}]},"id":"miabis-s1"}"#;
+
+    // sample_kind: IN ["blood-plasma","tissue-ffpe"]  →  also "Plasma","TissueFixed"
+    const MIABIS_SAMPLE_IN: &str = r#"{"ast":{"operand":"OR","children":[{"operand":"AND","children":[{"operand":"OR","children":[{"key":"sample_kind","type":"IN","system":"","value":["blood-plasma","tissue-ffpe"]}]}]}]},"id":"miabis-s2"}"#;
+
+    // sample_kind: "liquid-other"  →  also "LiquidBiopsy" AND "Sputum" (1:many)
+    const MIABIS_SAMPLE_LIQUID_OTHER: &str = r#"{"ast":{"operand":"OR","children":[{"operand":"AND","children":[{"operand":"OR","children":[{"key":"sample_kind","type":"IN","system":"","value":["liquid-other"]}]}]}]},"id":"miabis-s3"}"#;
 
     #[test]
-    fn test_miabis_gender() {
-        let cql = generate_cql(serde_json::from_str(MIABIS_FEMALE).unwrap(), Project::MiabisOnFhir)
-            .unwrap();
-        assert!(cql.contains("Patient.gender = 'female'"), "gender snippet missing");
-    }
-
-    #[test]
-    fn test_miabis_diagnosis() {
-        // MIABIS-on-FHIR 1.0.0 uses ICD-10 only — not the German GM variants.
+    fn test_miabis_storage_temperature_workarounds() {
+        // EQUALS "temperatureRoom" → original code kept AND "RT" added
         let cql = generate_cql(
-            serde_json::from_str(MIABIS_DIAGNOSIS_C34).unwrap(),
+            serde_json::from_str(MIABIS_TEMP_EQUALS_ROOM).unwrap(),
+            Project::MiabisOnFhir,
+        )
+        .unwrap();
+        assert!(cql.contains("'temperatureRoom'"), "original Lens code 'temperatureRoom' missing");
+        assert!(cql.contains("'RT'"), "MIABIS code 'RT' missing for temperatureRoom");
+
+        // EQUALS "four_degrees" → original code kept AND "2to10" added
+        let cql = generate_cql(
+            serde_json::from_str(MIABIS_TEMP_EQUALS_FOUR).unwrap(),
+            Project::MiabisOnFhir,
+        )
+        .unwrap();
+        assert!(cql.contains("'four_degrees'"), "original Lens code 'four_degrees' missing");
+        assert!(cql.contains("'2to10'"), "MIABIS code '2to10' missing for four_degrees");
+
+        // IN ["temperature2to10","temperatureGN"] → both originals kept AND "2to10","LN" added
+        let cql = generate_cql(
+            serde_json::from_str(MIABIS_TEMP_IN).unwrap(),
+            Project::MiabisOnFhir,
+        )
+        .unwrap();
+        assert!(cql.contains("'temperature2to10'"), "original Lens code 'temperature2to10' missing");
+        assert!(cql.contains("'2to10'"), "MIABIS code '2to10' missing for temperature2to10");
+        assert!(cql.contains("'temperatureGN'"), "original Lens code 'temperatureGN' missing");
+        assert!(cql.contains("'LN'"), "MIABIS code 'LN' missing for temperatureGN");
+
+        // "storage_temperature_uncharted" → no MIABIS equivalent; original kept, nothing added
+        let cql = generate_cql(
+            serde_json::from_str(MIABIS_TEMP_UNCHARTED).unwrap(),
             Project::MiabisOnFhir,
         )
         .unwrap();
         assert!(
-            cql.contains("exists[Condition: Code 'C34' from icd10]"),
-            "diagnosis snippet missing"
+            cql.contains("'storage_temperature_uncharted'"),
+            "original Lens code 'storage_temperature_uncharted' missing"
         );
-        assert!(
-            !cql.contains("icd10gm"),
-            "ICD-10-GM must not appear in MIABIS CQL"
-        );
+        // None of the MIABIS temperature codes should appear
+        for miabis_code in &["'RT'", "'2to10'", "'-18to-35'", "'-60to-85'", "'LN'", "'Other'"] {
+            assert!(
+                !cql.contains(miabis_code),
+                "unexpected MIABIS code {miabis_code} injected for storage_temperature_uncharted"
+            );
+        }
     }
 
     #[test]
-    fn test_miabis_sample_kind() {
-        // tissue-ffpe maps to the canonical code AND the MIABIS workaround code TissueFixed.
+    fn test_miabis_sample_type_workarounds() {
+        // EQUALS "whole-blood" → original kept AND "WholeBlood" added
         let cql = generate_cql(
-            serde_json::from_str(MIABIS_SAMPLE_KIND_FFPE).unwrap(),
+            serde_json::from_str(MIABIS_SAMPLE_EQUALS_WHOLE_BLOOD).unwrap(),
             Project::MiabisOnFhir,
         )
         .unwrap();
-        assert!(
-            cql.contains("exists [Specimen: Code 'tissue-ffpe' from MiabisDetailedSampleType]"),
-            "canonical tissue-ffpe query missing"
-        );
-        assert!(
-            cql.contains("exists [Specimen: Code 'TissueFixed' from MiabisDetailedSampleType]"),
-            "TissueFixed workaround missing"
-        );
-    }
+        assert!(cql.contains("'whole-blood'"), "original Lens code 'whole-blood' missing");
+        assert!(cql.contains("'WholeBlood'"), "MIABIS code 'WholeBlood' missing for whole-blood");
 
-    #[test]
-    fn test_miabis_storage_temperature() {
-        // Storage temperature is in Specimen.processing[].extension — the most
-        // MIABIS-specific path in the implementation.
+        // IN ["blood-plasma","tissue-ffpe"] → originals kept AND "Plasma","TissueFixed" added
         let cql = generate_cql(
-            serde_json::from_str(MIABIS_STORAGE_TEMP_LN).unwrap(),
+            serde_json::from_str(MIABIS_SAMPLE_IN).unwrap(),
             Project::MiabisOnFhir,
         )
         .unwrap();
-        assert!(
-            cql.contains("'https://fhir.bbmri-eric.eu/StructureDefinition/miabis-sample-storage-temperature-extension'"),
-            "storage temperature extension URL missing"
-        );
-        assert!(
-            cql.contains(".coding.code contains 'LN'"),
-            "storage temperature value match missing"
-        );
-        // S.processing appears in the InInitialPopulation query snippet;
-        // specimen.processing appears in the StorageTemperature function.
-        // Both must be present: the function must use the parameter (not the
-        // patient-level Specimen define) so Blaze evaluates it per-specimen.
-        assert!(
-            cql.contains("S.processing"),
-            "InInitialPopulation query must use Specimen.processing[], not Specimen.extension"
-        );
-        assert!(
-            cql.contains("specimen.processing"),
-            "StorageTemperature must be a function using its parameter, not the patient-level Specimen define"
-        );
+        assert!(cql.contains("'blood-plasma'"), "original Lens code 'blood-plasma' missing");
+        assert!(cql.contains("'Plasma'"), "MIABIS code 'Plasma' missing for blood-plasma");
+        assert!(cql.contains("'tissue-ffpe'"), "original Lens code 'tissue-ffpe' missing");
+        assert!(cql.contains("'TissueFixed'"), "MIABIS code 'TissueFixed' missing for tissue-ffpe");
+
+        // "liquid-other" → original kept AND both "LiquidBiopsy" AND "Sputum" added (1:many)
+        let cql = generate_cql(
+            serde_json::from_str(MIABIS_SAMPLE_LIQUID_OTHER).unwrap(),
+            Project::MiabisOnFhir,
+        )
+        .unwrap();
+        assert!(cql.contains("'liquid-other'"), "original Lens code 'liquid-other' missing");
+        assert!(cql.contains("'LiquidBiopsy'"), "MIABIS code 'LiquidBiopsy' missing for liquid-other");
+        assert!(cql.contains("'Sputum'"), "MIABIS code 'Sputum' missing for liquid-other");
     }
 }

--- a/src/cql.rs
+++ b/src/cql.rs
@@ -724,4 +724,100 @@ mod test {
     //     // pretty_assertions::assert_eq!(generated_cql.contains(expected), true);
     //     pretty_assertions::assert_eq!(false, true);
     // }
+
+    // ── MIABIS-on-FHIR 1.0.0 tests ───────────────────────────────────────────
+
+    const MIABIS_FEMALE: &str = r#"{"ast":{"operand":"OR","children":[{"operand":"AND","children":[{"operand":"OR","children":[{"key":"gender","type":"EQUALS","system":"","value":"female"}]}]}]},"id":"a6f1ccf3-ebf1-424f-9d69-4e5d135f2340"}"#;
+
+    const MIABIS_DIAGNOSIS_C34: &str = r#"{"ast":{"operand":"OR","children":[{"operand":"AND","children":[{"operand":"OR","children":[{"key":"diagnosis","type":"EQUALS","system":"http://hl7.org/fhir/sid/icd-10","value":"C34"}]}]}]},"id":"a6f1ccf3-ebf1-424f-9d69-4e5d135f2340"}"#;
+
+    const MIABIS_SAMPLE_KIND_FFPE: &str = r#"{"ast":{"operand":"OR","children":[{"operand":"AND","children":[{"operand":"OR","children":[{"key":"sample_kind","type":"EQUALS","system":"","value":"tissue-ffpe"}]}]}]},"id":"a6f1ccf3-ebf1-424f-9d69-4e5d135f2340"}"#;
+
+    const MIABIS_STORAGE_TEMP_LN: &str = r#"{"ast":{"operand":"OR","children":[{"operand":"AND","children":[{"operand":"OR","children":[{"key":"storage_temperature","type":"EQUALS","system":"","value":"LN"}]}]}]},"id":"a6f1ccf3-ebf1-424f-9d69-4e5d135f2340"}"#;
+
+    #[test]
+    fn test_miabis_empty() {
+        // An empty query must always declare both mandatory code systems so that
+        // SampleType() and DiagnosisCode() in the template can reference them.
+        let cql = generate_cql(serde_json::from_str(EMPTY).unwrap(), Project::MiabisOnFhir)
+            .unwrap();
+        assert!(
+            cql.contains("codesystem icd10: 'http://hl7.org/fhir/sid/icd-10'"),
+            "icd10 codesystem declaration missing"
+        );
+        assert!(
+            cql.contains("codesystem MiabisDetailedSampleType: 'https://fhir.bbmri-eric.eu/CodeSystem/miabis-detailed-samply-type-cs'"),
+            "MiabisDetailedSampleType codesystem declaration missing"
+        );
+        assert!(
+            cql.contains("define InInitialPopulation:\ntrue"),
+            "empty query should match all patients"
+        );
+    }
+
+    #[test]
+    fn test_miabis_gender() {
+        let cql = generate_cql(serde_json::from_str(MIABIS_FEMALE).unwrap(), Project::MiabisOnFhir)
+            .unwrap();
+        assert!(cql.contains("Patient.gender = 'female'"), "gender snippet missing");
+    }
+
+    #[test]
+    fn test_miabis_diagnosis() {
+        // MIABIS-on-FHIR 1.0.0 uses ICD-10 only — not the German GM variants.
+        let cql = generate_cql(
+            serde_json::from_str(MIABIS_DIAGNOSIS_C34).unwrap(),
+            Project::MiabisOnFhir,
+        )
+        .unwrap();
+        assert!(
+            cql.contains("exists[Condition: Code 'C34' from icd10]"),
+            "diagnosis snippet missing"
+        );
+        assert!(
+            !cql.contains("icd10gm"),
+            "ICD-10-GM must not appear in MIABIS CQL"
+        );
+    }
+
+    #[test]
+    fn test_miabis_sample_kind() {
+        // tissue-ffpe maps to the canonical code AND the MIABIS workaround code TissueFixed.
+        let cql = generate_cql(
+            serde_json::from_str(MIABIS_SAMPLE_KIND_FFPE).unwrap(),
+            Project::MiabisOnFhir,
+        )
+        .unwrap();
+        assert!(
+            cql.contains("exists [Specimen: Code 'tissue-ffpe' from MiabisDetailedSampleType]"),
+            "canonical tissue-ffpe query missing"
+        );
+        assert!(
+            cql.contains("exists [Specimen: Code 'TissueFixed' from MiabisDetailedSampleType]"),
+            "TissueFixed workaround missing"
+        );
+    }
+
+    #[test]
+    fn test_miabis_storage_temperature() {
+        // Storage temperature is in Specimen.processing[].extension — the most
+        // MIABIS-specific path in the implementation.
+        let cql = generate_cql(
+            serde_json::from_str(MIABIS_STORAGE_TEMP_LN).unwrap(),
+            Project::MiabisOnFhir,
+        )
+        .unwrap();
+        assert!(
+            cql.contains("'https://fhir.bbmri-eric.eu/StructureDefinition/miabis-sample-storage-temperature-extension'"),
+            "storage temperature extension URL missing"
+        );
+        assert!(
+            cql.contains(".coding.code contains 'LN'"),
+            "storage temperature value match missing"
+        );
+        assert!(
+            cql.contains("S.processing"),
+            "must query Specimen.processing[], not Specimen.extension"
+        );
+    }
 }

--- a/src/cql.rs
+++ b/src/cql.rs
@@ -815,9 +815,17 @@ mod test {
             cql.contains(".coding.code contains 'LN'"),
             "storage temperature value match missing"
         );
+        // S.processing appears in the InInitialPopulation query snippet;
+        // specimen.processing appears in the StorageTemperature function.
+        // Both must be present: the function must use the parameter (not the
+        // patient-level Specimen define) so Blaze evaluates it per-specimen.
         assert!(
             cql.contains("S.processing"),
-            "must query Specimen.processing[], not Specimen.extension"
+            "InInitialPopulation query must use Specimen.processing[], not Specimen.extension"
+        );
+        assert!(
+            cql.contains("specimen.processing"),
+            "StorageTemperature must be a function using its parameter, not the patient-level Specimen define"
         );
     }
 }

--- a/src/projects/miabis/body.json
+++ b/src/projects/miabis/body.json
@@ -1,0 +1,181 @@
+{
+  "lang": "cql",
+  "lib": {
+    "content": [
+      {
+        "contentType": "text/cql",
+        "data": "{{LIBRARY_ENCODED}}"
+      }
+    ],
+    "resourceType": "Library",
+    "status": "active",
+    "type": {
+      "coding": [
+        {
+          "code": "logic-library",
+          "system": "http://terminology.hl7.org/CodeSystem/library-type"
+        }
+      ]
+    },
+    "url": "{{LIBRARY_UUID}}"
+  },
+  "measure": {
+    "group": [
+      {
+        "code": {
+          "text": "patient"
+        },
+        "population": [
+          {
+            "code": {
+              "coding": [
+                {
+                  "code": "initial-population",
+                  "system": "http://terminology.hl7.org/CodeSystem/measure-population"
+                }
+              ]
+            },
+            "criteria": {
+              "expression": "InInitialPopulation",
+              "language": "text/cql-identifier"
+            }
+          }
+        ],
+        "stratifier": [
+          {
+            "code": {
+              "text": "gender"
+            },
+            "criteria": {
+              "expression": "Gender",
+              "language": "text/cql"
+            }
+          },
+          {
+            "code": {
+              "text": "donor_age"
+            },
+            "criteria": {
+              "expression": "AgeClass",
+              "language": "text/cql"
+            }
+          },
+          {
+            "code": {
+              "text": "Custodian"
+            },
+            "criteria": {
+              "expression": "Custodian",
+              "language": "text/cql"
+            }
+          }
+        ]
+      },
+      {
+        "code": {
+          "text": "diagnosis"
+        },
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-populationBasis",
+            "valueCode": "Condition"
+          }
+        ],
+        "population": [
+          {
+            "code": {
+              "coding": [
+                {
+                  "code": "initial-population",
+                  "system": "http://terminology.hl7.org/CodeSystem/measure-population"
+                }
+              ]
+            },
+            "criteria": {
+              "expression": "Diagnosis",
+              "language": "text/cql-identifier"
+            }
+          }
+        ],
+        "stratifier": [
+          {
+            "code": {
+              "text": "diagnosis"
+            },
+            "criteria": {
+              "expression": "DiagnosisCode",
+              "language": "text/cql"
+            }
+          }
+        ]
+      },
+      {
+        "code": {
+          "text": "specimen"
+        },
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-populationBasis",
+            "valueCode": "Specimen"
+          }
+        ],
+        "population": [
+          {
+            "code": {
+              "coding": [
+                {
+                  "code": "initial-population",
+                  "system": "http://terminology.hl7.org/CodeSystem/measure-population"
+                }
+              ]
+            },
+            "criteria": {
+              "expression": "Specimen",
+              "language": "text/cql-identifier"
+            }
+          }
+        ],
+        "stratifier": [
+          {
+            "code": {
+              "text": "sample_kind"
+            },
+            "criteria": {
+              "expression": "SampleType",
+              "language": "text/cql"
+            }
+          },
+          {
+            "code": {
+              "text": "storage_temperature"
+            },
+            "criteria": {
+              "expression": "StorageTemperature",
+              "language": "text/cql"
+            }
+          }
+        ]
+      }
+    ],
+    "library": "{{LIBRARY_UUID}}",
+    "resourceType": "Measure",
+    "scoring": {
+      "coding": [
+        {
+          "code": "cohort",
+          "system": "http://terminology.hl7.org/CodeSystem/measure-scoring"
+        }
+      ]
+    },
+    "status": "active",
+    "subjectCodeableConcept": {
+      "coding": [
+        {
+          "code": "Patient",
+          "system": "http://hl7.org/fhir/resource-types"
+        }
+      ]
+    },
+    "url": "{{MEASURE_UUID}}"
+  }
+}

--- a/src/projects/miabis/mod.rs
+++ b/src/projects/miabis/mod.rs
@@ -5,7 +5,7 @@ use indexmap::IndexSet;
 use super::CriterionRole;
 
 // CodeSystem URIs for MIABIS-on-FHIR 1.0.0
-// Hosted at https://fhir.bbmri-eric.eu (Czech BBMRI-cz IG)
+// IG hosted at https://fhir.miabis.bbmri-eric.eu/; resource URLs start with https://fhir.bbmri-eric.eu
 
 pub static CODE_LISTS: LazyLock<HashMap<&'static str, &'static str>> = LazyLock::new(|| {
     HashMap::from([

--- a/src/projects/miabis/mod.rs
+++ b/src/projects/miabis/mod.rs
@@ -5,7 +5,7 @@ use indexmap::IndexSet;
 use super::CriterionRole;
 
 // CodeSystem URIs for MIABIS-on-FHIR 1.0.0
-// IG hosted at https://fhir.miabis.bbmri-eric.eu/; canonical resource profile URLs use https://fhir.bbmri-eric.eu
+// Hosted at https://fhir.bbmri-eric.eu (Czech BBMRI-cz IG)
 
 pub static CODE_LISTS: LazyLock<HashMap<&'static str, &'static str>> = LazyLock::new(|| {
     HashMap::from([
@@ -132,5 +132,40 @@ pub static SAMPLE_TYPE_WORKAROUNDS: LazyLock<HashMap<&'static str, Vec<&'static 
             ("saliva",                      vec!["Saliva"]),
             ("stool-faeces",                vec!["Faeces"]),
             ("liquid-other",                vec!["LiquidBiopsy", "Sputum"]),
+        ])
+    });
+
+// Maps canonical Sample Locator storage temperature codes (sent by Lens) to the
+// MIABIS-on-FHIR 1.0.0 codes stored in the data
+// (miabis-storage-temperature-cs, hosted at https://fhir.bbmri-eric.eu).
+//
+// Lens code             MIABIS code   Notes
+// ─────────────────────────────────────────────────────────────────────────────
+// temperatureRoom       RT            Room temperature
+// temperature2to10      2to10         2–10 °C
+// four_degrees          2to10         4 °C is within the MIABIS 2–10 °C band;
+//                                     MIABIS has no dedicated 4 °C code
+// temperature-18to-35   -18to-35      −18 to −35 °C
+// temperature-60to-85   -60to-85      −60 to −85 °C
+// temperatureGN         LN            Gaseous/vapour-phase nitrogen (−150 to
+//                                     −196 °C); mapped to MIABIS LN (liquid
+//                                     nitrogen, same range) — closest available
+// temperatureLN         LN            Liquid nitrogen
+// temperatureOther      Other         Any other temperature
+//
+// Note: "storage_temperature_uncharted" has no MIABIS equivalent and is left
+// unmapped; queries for it will return zero results on MIABIS nodes, which is
+// the correct behaviour (the information is genuinely absent in the data model).
+pub static STORAGE_TEMPERATURE_WORKAROUNDS: LazyLock<HashMap<&'static str, Vec<&'static str>>> =
+    LazyLock::new(|| {
+        HashMap::from([
+            ("temperatureRoom",    vec!["RT"]),
+            ("temperature2to10",   vec!["2to10"]),
+            ("four_degrees",       vec!["2to10"]),
+            ("temperature-18to-35",vec!["-18to-35"]),
+            ("temperature-60to-85",vec!["-60to-85"]),
+            ("temperatureGN",      vec!["LN"]),
+            ("temperatureLN",      vec!["LN"]),
+            ("temperatureOther",   vec!["Other"]),
         ])
     });

--- a/src/projects/miabis/mod.rs
+++ b/src/projects/miabis/mod.rs
@@ -5,7 +5,7 @@ use indexmap::IndexSet;
 use super::CriterionRole;
 
 // CodeSystem URIs for MIABIS-on-FHIR 1.0.0
-// Hosted at https://fhir.bbmri-eric.eu (Czech BBMRI-cz IG)
+// IG hosted at https://fhir.miabis.bbmri-eric.eu/; canonical resource profile URLs use https://fhir.bbmri-eric.eu
 
 pub static CODE_LISTS: LazyLock<HashMap<&'static str, &'static str>> = LazyLock::new(|| {
     HashMap::from([

--- a/src/projects/miabis/mod.rs
+++ b/src/projects/miabis/mod.rs
@@ -1,0 +1,136 @@
+use std::{collections::HashMap, sync::LazyLock};
+
+use indexmap::IndexSet;
+
+use super::CriterionRole;
+
+// CodeSystem URIs for MIABIS-on-FHIR 1.0.0
+// Hosted at https://fhir.bbmri-eric.eu (Czech BBMRI-cz IG)
+
+pub static CODE_LISTS: LazyLock<HashMap<&'static str, &'static str>> = LazyLock::new(|| {
+    HashMap::from([
+        ("icd10", "http://hl7.org/fhir/sid/icd-10"),
+        (
+            "MiabisDetailedSampleType",
+            "https://fhir.bbmri-eric.eu/CodeSystem/miabis-detailed-samply-type-cs",
+        ),
+    ])
+});
+
+// MIABIS-on-FHIR 1.0.0 does not define observation-based criteria.
+pub static OBSERVATION_LOINC_CODES: LazyLock<HashMap<&'static str, &'static str>> =
+    LazyLock::new(HashMap::new);
+
+pub static CRITERION_CODE_LISTS: LazyLock<HashMap<&'static str, Vec<&'static str>>> =
+    LazyLock::new(|| {
+        HashMap::from([
+            ("diagnosis", vec!["icd10"]),
+            ("sample_kind", vec!["MiabisDetailedSampleType"]),
+            // storage_temperature uses extension URL matching, no declared codesystem needed
+        ])
+    });
+
+pub static CQL_SNIPPETS: LazyLock<HashMap<(&'static str, CriterionRole), &'static str>> =
+    LazyLock::new(|| {
+        HashMap::from([
+            // ── Patient-level criteria ────────────────────────────────────────────────
+            (
+                ("gender", CriterionRole::Query),
+                "Patient.gender = '{{C}}'",
+            ),
+            // MIABIS uses ICD-10 only — no German ICD-10-GM variants,
+            // no SampleDiagnosis specimen extension.
+            (
+                ("diagnosis", CriterionRole::Query),
+                "exists[Condition: Code '{{C}}' from {{A1}}]",
+            ),
+            (
+                ("date_of_diagnosis", CriterionRole::Query),
+                "exists from [Condition] C\nwhere FHIRHelpers.ToDateTime(C.onset) between {{D1}} and {{D2}}",
+            ),
+            (
+                ("diagnosis_age_donor", CriterionRole::Query),
+                "exists from [Condition] C\nwhere AgeInYearsAt(FHIRHelpers.ToDateTime(C.onset)) between Ceiling({{D1}}) and Ceiling({{D2}})",
+            ),
+            (
+                ("donor_age", CriterionRole::Query),
+                "AgeInYears() between Ceiling({{D1}}) and Ceiling({{D2}})",
+            ),
+
+            // ── Specimen-level criteria ───────────────────────────────────────────────
+            //
+            // sample_kind: uses the MIABIS detailed sample type CodeSystem.
+            // SAMPLE_TYPE_WORKAROUNDS maps canonical Sample Locator codes
+            // (e.g. "blood-plasma") to MIABIS codes (e.g. "Plasma").
+            (
+                ("sample_kind", CriterionRole::Query),
+                "exists [Specimen: Code '{{C}}' from {{A1}}]",
+            ),
+            (
+                ("sample_kind", CriterionRole::Filter),
+                "(S.type.coding.where(system = 'https://fhir.bbmri-eric.eu/CodeSystem/miabis-detailed-samply-type-cs').code contains '{{C}}')",
+            ),
+
+            // storage_temperature: MIABIS places the extension in
+            // Specimen.processing[].extension, not Specimen.extension directly.
+            // Nested 'from P.extension' avoids the Blaze "name cannot be null" error.
+            (
+                ("storage_temperature", CriterionRole::Query),
+                "exists from [Specimen] S where (\
+                    exists from S.processing P where (\
+                        exists from P.extension E where \
+                            E.url = 'https://fhir.bbmri-eric.eu/StructureDefinition/miabis-sample-storage-temperature-extension' \
+                            and (E.value as CodeableConcept).coding.code contains '{{C}}'\
+                    )\
+                )",
+            ),
+            (
+                ("storage_temperature", CriterionRole::Filter),
+                "(exists from S.processing P where (\
+                    exists from P.extension E where \
+                        E.url = 'https://fhir.bbmri-eric.eu/StructureDefinition/miabis-sample-storage-temperature-extension' \
+                        and (E.value as CodeableConcept).coding.code contains '{{C}}'\
+                ))",
+            ),
+
+            // sampling_date: same path as de.bbmri.fhir
+            (
+                ("sampling_date", CriterionRole::Query),
+                "exists from [Specimen] S\nwhere FHIRHelpers.ToDateTime(S.collection.collected) between {{D1}} and {{D2}}",
+            ),
+            (
+                ("sampling_date", CriterionRole::Filter),
+                "(FHIRHelpers.ToDateTime(S.collection.collected) between {{D1}} and {{D2}})",
+            ),
+        ])
+    });
+
+// icd10 and MiabisDetailedSampleType are always declared in the generated CQL
+// so that the template's SampleType function and DiagnosisCode function can
+// reference them even when no search criteria are specified.
+pub static MANDATORY_CODE_LISTS: LazyLock<IndexSet<&'static str>> =
+    LazyLock::new(|| IndexSet::from(["icd10", "MiabisDetailedSampleType"]));
+
+// Maps canonical Sample Locator codes to the MIABIS-on-FHIR 1.0.0 codes
+// stored in the data (miabis-detailed-samply-type-cs).
+// When a user searches for e.g. "blood-plasma", focus also filters for "Plasma".
+pub static SAMPLE_TYPE_WORKAROUNDS: LazyLock<HashMap<&'static str, Vec<&'static str>>> =
+    LazyLock::new(|| {
+        HashMap::from([
+            ("whole-blood",                 vec!["WholeBlood"]),
+            ("buffy-coat",                  vec!["BuffyCoat"]),
+            ("blood-plasma",                vec!["Plasma"]),
+            ("blood-serum",                 vec!["Serum"]),
+            ("dna",                         vec!["DNA"]),
+            ("rna",                         vec!["RNA"]),
+            ("peripheral-blood-cells-vital",vec!["PBMC"]),
+            ("tissue-frozen",               vec!["TissueFreshFrozen"]),
+            ("tissue-ffpe",                 vec!["TissueFixed"]),
+            ("bone-marrow",                 vec!["BoneMarrowAspirate"]),
+            ("csf-liquor",                  vec!["CerebrospinalFluid"]),
+            ("urine",                       vec!["Urine"]),
+            ("saliva",                      vec!["Saliva"]),
+            ("stool-faeces",                vec!["Faeces"]),
+            ("liquid-other",                vec!["LiquidBiopsy", "Sputum"]),
+        ])
+    });

--- a/src/projects/miabis/template.cql
+++ b/src/projects/miabis/template.cql
@@ -1,0 +1,77 @@
+library Retrieve
+using FHIR version '4.0.1'
+include FHIRHelpers version '4.0.1'
+
+{{lists}}
+
+context Patient
+
+define AgeClass:
+if (Patient.birthDate is null) then 'unknown' else ToString((AgeInYears() div 10) * 10)
+
+define Gender:
+if (Patient.gender is null) then 'unknown' else Patient.gender
+
+// Collection identifier via valueIdentifier.
+// KEY DIFFERENCE from de.bbmri.fhir: link is valueIdentifier, not valueReference.
+define Custodian:
+    First(
+        from Specimen.extension E
+        where E.url = 'https://fhir.bbmri-eric.eu/StructureDefinition/miabis-sample-collection-extension'
+        return (E.value as Identifier).value
+    )
+
+// Map MIABIS-on-FHIR 1.0.0 sample type codes to canonical Sample Locator labels.
+// CodeSystem: https://fhir.bbmri-eric.eu/CodeSystem/miabis-detailed-samply-type-cs
+define function SampleType(specimen FHIR.Specimen):
+    case FHIRHelpers.ToCode(specimen.type.coding.where(system = 'https://fhir.bbmri-eric.eu/CodeSystem/miabis-detailed-samply-type-cs').first())
+       when Code 'WholeBlood'         from MiabisDetailedSampleType then 'whole-blood'
+       when Code 'BuffyCoat'          from MiabisDetailedSampleType then 'buffy-coat'
+       when Code 'Plasma'             from MiabisDetailedSampleType then 'blood-plasma'
+       when Code 'Serum'              from MiabisDetailedSampleType then 'blood-serum'
+       when Code 'DNA'                from MiabisDetailedSampleType then 'dna'
+       when Code 'RNA'                from MiabisDetailedSampleType then 'rna'
+       when Code 'PBMC'               from MiabisDetailedSampleType then 'peripheral-blood-cells-vital'
+       when Code 'TissueFreshFrozen'  from MiabisDetailedSampleType then 'tissue-frozen'
+       when Code 'TissueFixed'        from MiabisDetailedSampleType then 'tissue-ffpe'
+       when Code 'BoneMarrowAspirate' from MiabisDetailedSampleType then 'bone-marrow'
+       when Code 'CerebrospinalFluid' from MiabisDetailedSampleType then 'csf-liquor'
+       when Code 'Urine'              from MiabisDetailedSampleType then 'urine'
+       when Code 'Saliva'             from MiabisDetailedSampleType then 'saliva'
+       when Code 'Faeces'             from MiabisDetailedSampleType then 'stool-faeces'
+       when Code 'LiquidBiopsy'       from MiabisDetailedSampleType then 'liquid-other'
+       when Code 'Sputum'             from MiabisDetailedSampleType then 'liquid-other'
+       when null                      then 'Unknown'
+       else                                'Unknown'
+    end
+
+// Storage temperature: MIABIS-on-FHIR 1.0.0 places the extension in
+// Specimen.processing[].extension, not in Specimen.extension directly.
+// Nested 'from P.extension' avoids the Blaze "name cannot be null" error
+// that occurs when using flatten(processing.extension) + where E.url.
+define StorageTemperature:
+    First(
+        from Specimen.processing P
+        return First(
+            from P.extension E
+            where E.url = 'https://fhir.bbmri-eric.eu/StructureDefinition/miabis-sample-storage-temperature-extension'
+            return FHIRHelpers.ToString((E.value as CodeableConcept).coding.first().code)
+        )
+    )
+
+define Specimen:
+    if InInitialPopulation then [Specimen] S {{filter_criteria}} else {} as List<Specimen>
+
+define Diagnosis:
+    if InInitialPopulation then [Condition] else {} as List<Condition>
+
+// MIABIS-on-FHIR 1.0.0 uses ICD-10 only (http://hl7.org/fhir/sid/icd-10).
+// No German ICD-10-GM variant, no SampleDiagnosis specimen extension.
+define function DiagnosisCode(condition FHIR.Condition, specimen FHIR.Specimen):
+    condition.code.coding.where(system = 'http://hl7.org/fhir/sid/icd-10').code.first()
+
+define function DiagnosisCode(condition FHIR.Condition):
+    condition.code.coding.where(system = 'http://hl7.org/fhir/sid/icd-10').code.first()
+
+define InInitialPopulation:
+{{retrieval_criteria}}

--- a/src/projects/miabis/template.cql
+++ b/src/projects/miabis/template.cql
@@ -49,9 +49,11 @@ define function SampleType(specimen FHIR.Specimen):
 // Specimen.processing[].extension, not in Specimen.extension directly.
 // Nested 'from P.extension' avoids the Blaze "name cannot be null" error
 // that occurs when using flatten(processing.extension) + where E.url.
-define StorageTemperature:
+// Defined as a function (not a define) so Blaze evaluates it per-specimen
+// in the specimen stratifier, consistent with SampleType().
+define function StorageTemperature(specimen FHIR.Specimen):
     First(
-        from Specimen.processing P
+        from specimen.processing P
         return First(
             from P.extension E
             where E.url = 'https://fhir.bbmri-eric.eu/StructureDefinition/miabis-sample-storage-temperature-extension'

--- a/src/projects/mod.rs
+++ b/src/projects/mod.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, hash::Hash, str::FromStr};
+use std::{collections::HashMap, hash::Hash, str::FromStr, sync::LazyLock};
 
 use indexmap::IndexSet;
 
@@ -48,6 +48,11 @@ impl FromStr for Project {
     }
 }
 
+// Shared empty map returned by get_storage_temperature_workarounds() for all
+// projects that do not define their own storage temperature code mapping.
+static EMPTY_WORKAROUNDS: LazyLock<HashMap<&'static str, Vec<&'static str>>> =
+    LazyLock::new(HashMap::new);
+
 impl Project {
     pub fn get_code_lists(&self) -> &'static HashMap<&'static str, &'static str> {
         match self {
@@ -85,6 +90,18 @@ impl Project {
             Project::Itcc => &itcc::SAMPLE_TYPE_WORKAROUNDS,
             Project::MiabisOnFhir => &miabis::SAMPLE_TYPE_WORKAROUNDS,
             Project::Pscc => &pscc::SAMPLE_TYPE_WORKAROUNDS,
+        }
+    }
+
+    /// Maps canonical Lens storage-temperature codes to the project-specific codes
+    /// stored in the FHIR data.  Only MIABIS-on-FHIR requires a non-trivial mapping;
+    /// all other projects return an empty map (their codes already match what Lens sends).
+    pub fn get_storage_temperature_workarounds(
+        &self,
+    ) -> &'static HashMap<&'static str, Vec<&'static str>> {
+        match self {
+            Project::MiabisOnFhir => &miabis::STORAGE_TEMPERATURE_WORKAROUNDS,
+            _ => &EMPTY_WORKAROUNDS,
         }
     }
 

--- a/src/projects/mod.rs
+++ b/src/projects/mod.rs
@@ -9,6 +9,7 @@ mod cce;
 mod dhki;
 mod dktk;
 mod itcc;
+mod miabis;
 mod nngm;
 mod pscc;
 
@@ -25,6 +26,7 @@ pub enum Project {
     Dhki,
     Nngm,
     Itcc,
+    MiabisOnFhir,
     Pscc,
 }
 
@@ -39,6 +41,7 @@ impl FromStr for Project {
             "nngm" => Ok(Project::Nngm),
             "dhki" => Ok(Project::Dhki),
             "itcc" => Ok(Project::Itcc),
+            "miabis" => Ok(Project::MiabisOnFhir),
             "pscc" => Ok(Project::Pscc),
             _ => Err(FocusError::UnknownProject(s.to_string())),
         }
@@ -54,6 +57,7 @@ impl Project {
             Project::Dhki => &dhki::CODE_LISTS,
             Project::Nngm => &nngm::CODE_LISTS,
             Project::Itcc => &itcc::CODE_LISTS,
+            Project::MiabisOnFhir => &miabis::CODE_LISTS,
             Project::Pscc => &pscc::CODE_LISTS,
         }
     }
@@ -66,6 +70,7 @@ impl Project {
             Project::Dhki => &dhki::OBSERVATION_LOINC_CODES,
             Project::Nngm => &nngm::OBSERVATION_LOINC_CODES,
             Project::Itcc => &itcc::OBSERVATION_LOINC_CODES,
+            Project::MiabisOnFhir => &miabis::OBSERVATION_LOINC_CODES,
             Project::Pscc => &pscc::OBSERVATION_LOINC_CODES,
         }
     }
@@ -78,6 +83,7 @@ impl Project {
             Project::Dhki => &dhki::SAMPLE_TYPE_WORKAROUNDS,
             Project::Nngm => &nngm::SAMPLE_TYPE_WORKAROUNDS,
             Project::Itcc => &itcc::SAMPLE_TYPE_WORKAROUNDS,
+            Project::MiabisOnFhir => &miabis::SAMPLE_TYPE_WORKAROUNDS,
             Project::Pscc => &pscc::SAMPLE_TYPE_WORKAROUNDS,
         }
     }
@@ -90,6 +96,7 @@ impl Project {
             Project::Dhki => &dhki::CRITERION_CODE_LISTS,
             Project::Nngm => &nngm::CRITERION_CODE_LISTS,
             Project::Itcc => &itcc::CRITERION_CODE_LISTS,
+            Project::MiabisOnFhir => &miabis::CRITERION_CODE_LISTS,
             Project::Pscc => &pscc::CRITERION_CODE_LISTS,
         }
     }
@@ -104,6 +111,7 @@ impl Project {
             Project::Dhki => &dhki::CQL_SNIPPETS,
             Project::Nngm => &nngm::CQL_SNIPPETS,
             Project::Itcc => &itcc::CQL_SNIPPETS,
+            Project::MiabisOnFhir => &miabis::CQL_SNIPPETS,
             Project::Pscc => &pscc::CQL_SNIPPETS,
         }
     }
@@ -117,6 +125,7 @@ impl Project {
             Project::Nngm => &nngm::MANDATORY_CODE_LISTS,
             Project::Pscc => &pscc::MANDATORY_CODE_LISTS,
             Project::Itcc => &itcc::MANDATORY_CODE_LISTS,
+            Project::MiabisOnFhir => &miabis::MANDATORY_CODE_LISTS,
         }
     }
 
@@ -128,6 +137,7 @@ impl Project {
             Project::Dhki => include_str!("dhki/template.cql"),
             Project::Nngm => include_str!("nngm/template.cql"),
             Project::Itcc => include_str!("itcc/template.cql"),
+            Project::MiabisOnFhir => include_str!("miabis/template.cql"),
             Project::Pscc => include_str!("pscc/template.cql"),
         }
     }
@@ -140,6 +150,7 @@ impl Project {
             Project::Dhki => include_str!("dhki/body.json"),
             Project::Nngm => include_str!("nngm/body.json"),
             Project::Itcc => include_str!("itcc/body.json"),
+            Project::MiabisOnFhir => include_str!("miabis/body.json"),
             Project::Pscc => include_str!("pscc/body.json"),
         }
     }


### PR DESCRIPTION
 ## Summary

  - Adds a new `miabis` project backed by the MIABIS-on-FHIR 1.0.0
    Implementation Guide (hosted at https://fhir.miabis.bbmri-eric.eu/;
    canonical resource profile URLs use https://fhir.bbmri-eric.eu)
  - New project selectable via `metadata.project = "miabis"` in Beam tasks
  - Supports patient, diagnosis (Condition), and specimen groups with stratifiers
  - Search criteria: gender, donor_age, Custodian, diagnosis (ICD-10), sample_kind, storage_temperature, sampling_date
  - Additive change — all existing projects (bbmri, dktk, …) are unaffected

  ## Key Differences from `bbmri` (de.bbmri.fhir)

  | Aspect | bbmri | miabis |
  |---|---|---|
  | Sample type CodeSystem | `SampleMaterialType` | `miabis-detailed-samply-type-cs` — `SAMPLE_TYPE_WORKAROUNDS` maps Sample Locator codes to MIABIS codes, both ORed into CQL |
  | Storage temperature codes | Lens canonical codes match data | `STORAGE_TEMPERATURE_WORKAROUNDS` maps Lens codes (e.g. `temperatureRoom`) to MIABIS codes (e.g. `RT`), both ORed into CQL;
  `storage_temperature_uncharted` intentionally unmapped |
  | Storage temperature location | `Specimen.extension` | `Specimen.processing[].extension` — `StorageTemperature()` is a function (not a define) so Blaze evaluates it per-specimen in the stratifier |
  | Custodian link | `valueReference` | `valueIdentifier` |
  | Diagnosis | ICD-10 + ICD-10-GM variants | ICD-10 only (`http://hl7.org/fhir/sid/icd-10`) |

  ## Files Modified

  - `src/projects/miabis/mod.rs` — code list URIs, CQL snippets, `SAMPLE_TYPE_WORKAROUNDS`, `STORAGE_TEMPERATURE_WORKAROUNDS`, mandatory code lists
  - `src/projects/miabis/template.cql` — CQL template with `SampleType()`, `StorageTemperature()`, `Custodian`, `DiagnosisCode()`
  - `src/projects/miabis/body.json` — FHIR Measure definition
  - `src/projects/mod.rs` — new `MiabisOnFhir` enum variant wired into all getter methods; `get_storage_temperature_workarounds()` method; shared `EMPTY_WORKAROUNDS` for other projects
  - `src/cql.rs` — wires `SAMPLE_TYPE_WORKAROUNDS` and `STORAGE_TEMPERATURE_WORKAROUNDS` into CQL generation for `ConditionType::In` and `::Equals`

  ## Testing

  **Unit tests** (`cargo test test_miabis`, no external services): two test functions covering the workaround mechanism — `test_miabis_storage_temperature_workarounds` (EQUALS with mapping, EQUALS with 1:1
  mapping, IN with multiple mappings, unmapped code passthrough) and `test_miabis_sample_type_workarounds` (EQUALS, IN, 1:many mapping).

  **End-to-end test** (`dev/test_miabis_e2e.sh`, requires Docker): self-contained script with test data in `resources/test/miabis_e2e_bundle.json`. Starts Blaze, loads the bundle, runs focus against a mock
  Beam proxy, and verifies 14 counts in the MeasureReport. Found and fixed a real bug: `StorageTemperature` was a patient-level `define`, causing all specimens of a patient to inherit the first specimen's
  temperature.

  **Extended E2E suite** (10 scenarios, 1–25 donors, 1–5 collections, up to 59 specimens): 269 checks, 0 failures. Synthetic bundles generated via
  [a-tuerk/miabis_on_fhir_synth](https://github.com/a-tuerk/miabis_on_fhir_synth). The companion repo [a-tuerk/miabis_on_fhir_bridgehead](https://github.com/a-tuerk/miabis_on_fhir_bridgehead) contains two
  additional test scripts not part of this PR: `test_miabis_branch.sh` (5 targeted scenarios testing code translation and empty-AST behaviour) and `run_e2e_suite.py` (10 synthetic-bundle scenarios, 269 counts
  verified).

