### PR TITLE
feat(miabis): add MIABIS-on-FHIR CQL flavour + rustyspot 0.2.x compat fix

### DIFF
--- a/src/cql.rs
+++ b/src/cql.rs
@@ -779,7 +779,6 @@ mod test {
 
     #[test]
     fn test_miabis_sample_kind() {
-        // EQUALS: original Lens code is kept alongside the MIABIS workaround code
         let cql = generate_cql(
             serde_json::from_str(MIABIS_SAMPLE_EQUALS_WHOLE_BLOOD).unwrap(),
             Flavour::Miabis,
@@ -794,7 +793,6 @@ mod test {
 
     #[test]
     fn test_miabis_storage_temperature() {
-        // EQUALS: original Lens code is kept alongside the MIABIS workaround code
         let cql = generate_cql(
             serde_json::from_str(MIABIS_TEMP_EQUALS_ROOM).unwrap(),
             Flavour::Miabis,
@@ -810,7 +808,6 @@ mod test {
 
     #[test]
     fn test_miabis_sample_type_workarounds() {
-        // EQUALS: original Lens code kept, MIABIS code appended
         let cql = generate_cql(
             serde_json::from_str(MIABIS_SAMPLE_EQUALS_WHOLE_BLOOD).unwrap(),
             Flavour::Miabis,
@@ -819,8 +816,6 @@ mod test {
         assert!(cql.contains("'whole-blood'"));
         assert!(cql.contains("'WholeBlood'"));
 
-        // IN: MIABIS codes present (Lens codes not checked — they appear in the
-        // SampleType case expression in template.cql regardless of search criteria)
         let cql = generate_cql(
             serde_json::from_str(MIABIS_SAMPLE_IN).unwrap(),
             Flavour::Miabis,
@@ -829,7 +824,6 @@ mod test {
         assert!(cql.contains("'Plasma'"));
         assert!(cql.contains("'TissueFixed'"));
 
-        // IN: liquid-other maps to two MIABIS codes (1:many)
         let cql = generate_cql(
             serde_json::from_str(MIABIS_SAMPLE_LIQUID_OTHER).unwrap(),
             Flavour::Miabis,
@@ -841,7 +835,6 @@ mod test {
 
     #[test]
     fn test_miabis_storage_temperature_workarounds() {
-        // EQUALS: original Lens code kept, MIABIS code appended
         let cql = generate_cql(
             serde_json::from_str(MIABIS_TEMP_EQUALS_ROOM).unwrap(),
             Flavour::Miabis,
@@ -858,7 +851,6 @@ mod test {
         assert!(cql.contains("'four_degrees'"));
         assert!(cql.contains("'2to10'"));
 
-        // IN: original Lens codes dropped, only MIABIS codes present
         let cql = generate_cql(
             serde_json::from_str(MIABIS_TEMP_IN).unwrap(),
             Flavour::Miabis,
@@ -869,8 +861,6 @@ mod test {
         assert!(!cql.contains("'temperatureGN'"));
         assert!(cql.contains("'LN'"));
 
-        // EQUALS: storage_temperature_uncharted has no MIABIS equivalent;
-        // original code is kept (EQUALS always includes it), no MIABIS codes injected
         let cql = generate_cql(
             serde_json::from_str(MIABIS_TEMP_UNCHARTED).unwrap(),
             Flavour::Miabis,

--- a/src/cql.rs
+++ b/src/cql.rs
@@ -734,4 +734,151 @@ mod test {
     //     // pretty_assertions::assert_eq!(generated_cql.contains(expected), true);
     //     pretty_assertions::assert_eq!(false, true);
     // }
+
+    const MIABIS_DIAGNOSIS: &str = r#"{"ast":{"operand":"OR","children":[{"operand":"AND","children":[{"operand":"OR","children":[{"key":"diagnosis","type":"EQUALS","system":"","value":"C61"}]}]}]},"id":"miabis-d1"}"#;
+
+    const MIABIS_SAMPLE_EQUALS_WHOLE_BLOOD: &str = r#"{"ast":{"operand":"OR","children":[{"operand":"AND","children":[{"operand":"OR","children":[{"key":"sample_kind","type":"EQUALS","system":"","value":"whole-blood"}]}]}]},"id":"miabis-s1"}"#;
+
+    const MIABIS_SAMPLE_IN: &str = r#"{"ast":{"operand":"OR","children":[{"operand":"AND","children":[{"operand":"OR","children":[{"key":"sample_kind","type":"IN","system":"","value":["blood-plasma","tissue-ffpe"]}]}]}]},"id":"miabis-s2"}"#;
+
+    const MIABIS_SAMPLE_LIQUID_OTHER: &str = r#"{"ast":{"operand":"OR","children":[{"operand":"AND","children":[{"operand":"OR","children":[{"key":"sample_kind","type":"IN","system":"","value":["liquid-other"]}]}]}]},"id":"miabis-s3"}"#;
+
+    const MIABIS_TEMP_EQUALS_ROOM: &str = r#"{"ast":{"operand":"OR","children":[{"operand":"AND","children":[{"operand":"OR","children":[{"key":"storage_temperature","type":"EQUALS","system":"","value":"temperatureRoom"}]}]}]},"id":"miabis-t1"}"#;
+
+    const MIABIS_TEMP_EQUALS_FOUR: &str = r#"{"ast":{"operand":"OR","children":[{"operand":"AND","children":[{"operand":"OR","children":[{"key":"storage_temperature","type":"EQUALS","system":"","value":"four_degrees"}]}]}]},"id":"miabis-t2"}"#;
+
+    const MIABIS_TEMP_IN: &str = r#"{"ast":{"operand":"OR","children":[{"operand":"AND","children":[{"operand":"OR","children":[{"key":"storage_temperature","type":"IN","system":"","value":["temperature2to10","temperatureGN"]}]}]}]},"id":"miabis-t3"}"#;
+
+    const MIABIS_TEMP_UNCHARTED: &str = r#"{"ast":{"operand":"OR","children":[{"operand":"AND","children":[{"operand":"OR","children":[{"key":"storage_temperature","type":"EQUALS","system":"","value":"storage_temperature_uncharted"}]}]}]},"id":"miabis-t4"}"#;
+
+    #[test]
+    fn test_miabis_empty() {
+        let cql = generate_cql(serde_json::from_str(EMPTY).unwrap(), Flavour::Miabis).unwrap();
+        assert!(cql.contains("http://hl7.org/fhir/sid/icd-10"));
+        assert!(cql.contains(
+            "https://fhir.bbmri-eric.eu/CodeSystem/miabis-detailed-samply-type-cs"
+        ));
+    }
+
+    #[test]
+    fn test_miabis_gender() {
+        let cql =
+            generate_cql(serde_json::from_str(MALE_OR_FEMALE).unwrap(), Flavour::Miabis).unwrap();
+        assert!(cql.contains("Patient.gender = 'male'"));
+        assert!(cql.contains("Patient.gender = 'female'"));
+    }
+
+    #[test]
+    fn test_miabis_diagnosis() {
+        let cql =
+            generate_cql(serde_json::from_str(MIABIS_DIAGNOSIS).unwrap(), Flavour::Miabis).unwrap();
+        assert!(cql.contains("'C61'"));
+        assert!(cql.contains("http://hl7.org/fhir/sid/icd-10"));
+        assert!(!cql.contains("http://fhir.de/CodeSystem/dimdi/icd-10-gm"));
+    }
+
+    #[test]
+    fn test_miabis_sample_kind() {
+        // EQUALS: original Lens code is kept alongside the MIABIS workaround code
+        let cql = generate_cql(
+            serde_json::from_str(MIABIS_SAMPLE_EQUALS_WHOLE_BLOOD).unwrap(),
+            Flavour::Miabis,
+        )
+        .unwrap();
+        assert!(cql.contains("'whole-blood'"));
+        assert!(cql.contains("'WholeBlood'"));
+        assert!(cql.contains(
+            "https://fhir.bbmri-eric.eu/CodeSystem/miabis-detailed-samply-type-cs"
+        ));
+    }
+
+    #[test]
+    fn test_miabis_storage_temperature() {
+        // EQUALS: original Lens code is kept alongside the MIABIS workaround code
+        let cql = generate_cql(
+            serde_json::from_str(MIABIS_TEMP_EQUALS_ROOM).unwrap(),
+            Flavour::Miabis,
+        )
+        .unwrap();
+        assert!(cql.contains("'temperatureRoom'"));
+        assert!(cql.contains("'RT'"));
+        assert!(cql.contains("Specimen.processing"));
+        assert!(cql.contains(
+            "https://fhir.bbmri-eric.eu/StructureDefinition/miabis-sample-storage-temperature-extension"
+        ));
+    }
+
+    #[test]
+    fn test_miabis_sample_type_workarounds() {
+        // EQUALS: original Lens code kept, MIABIS code appended
+        let cql = generate_cql(
+            serde_json::from_str(MIABIS_SAMPLE_EQUALS_WHOLE_BLOOD).unwrap(),
+            Flavour::Miabis,
+        )
+        .unwrap();
+        assert!(cql.contains("'whole-blood'"));
+        assert!(cql.contains("'WholeBlood'"));
+
+        // IN: MIABIS codes present (Lens codes not checked — they appear in the
+        // SampleType case expression in template.cql regardless of search criteria)
+        let cql = generate_cql(
+            serde_json::from_str(MIABIS_SAMPLE_IN).unwrap(),
+            Flavour::Miabis,
+        )
+        .unwrap();
+        assert!(cql.contains("'Plasma'"));
+        assert!(cql.contains("'TissueFixed'"));
+
+        // IN: liquid-other maps to two MIABIS codes (1:many)
+        let cql = generate_cql(
+            serde_json::from_str(MIABIS_SAMPLE_LIQUID_OTHER).unwrap(),
+            Flavour::Miabis,
+        )
+        .unwrap();
+        assert!(cql.contains("'LiquidBiopsy'"));
+        assert!(cql.contains("'Sputum'"));
+    }
+
+    #[test]
+    fn test_miabis_storage_temperature_workarounds() {
+        // EQUALS: original Lens code kept, MIABIS code appended
+        let cql = generate_cql(
+            serde_json::from_str(MIABIS_TEMP_EQUALS_ROOM).unwrap(),
+            Flavour::Miabis,
+        )
+        .unwrap();
+        assert!(cql.contains("'temperatureRoom'"));
+        assert!(cql.contains("'RT'"));
+
+        let cql = generate_cql(
+            serde_json::from_str(MIABIS_TEMP_EQUALS_FOUR).unwrap(),
+            Flavour::Miabis,
+        )
+        .unwrap();
+        assert!(cql.contains("'four_degrees'"));
+        assert!(cql.contains("'2to10'"));
+
+        // IN: original Lens codes dropped, only MIABIS codes present
+        let cql = generate_cql(
+            serde_json::from_str(MIABIS_TEMP_IN).unwrap(),
+            Flavour::Miabis,
+        )
+        .unwrap();
+        assert!(!cql.contains("'temperature2to10'"));
+        assert!(cql.contains("'2to10'"));
+        assert!(!cql.contains("'temperatureGN'"));
+        assert!(cql.contains("'LN'"));
+
+        // EQUALS: storage_temperature_uncharted has no MIABIS equivalent;
+        // original code is kept (EQUALS always includes it), no MIABIS codes injected
+        let cql = generate_cql(
+            serde_json::from_str(MIABIS_TEMP_UNCHARTED).unwrap(),
+            Flavour::Miabis,
+        )
+        .unwrap();
+        assert!(cql.contains("'storage_temperature_uncharted'"));
+        for miabis_code in &["'RT'", "'2to10'", "'-18to-35'", "'-60to-85'", "'LN'", "'Other'"] {
+            assert!(!cql.contains(miabis_code));
+        }
+    }
 }

--- a/src/flavours/miabis/body.json
+++ b/src/flavours/miabis/body.json
@@ -1,1 +1,181 @@
-{"todo": "replace with miabis body"}
+{
+  "lang": "cql",
+  "lib": {
+    "content": [
+      {
+        "contentType": "text/cql",
+        "data": "{{LIBRARY_ENCODED}}"
+      }
+    ],
+    "resourceType": "Library",
+    "status": "active",
+    "type": {
+      "coding": [
+        {
+          "code": "logic-library",
+          "system": "http://terminology.hl7.org/CodeSystem/library-type"
+        }
+      ]
+    },
+    "url": "{{LIBRARY_UUID}}"
+  },
+  "measure": {
+    "group": [
+      {
+        "code": {
+          "text": "patient"
+        },
+        "population": [
+          {
+            "code": {
+              "coding": [
+                {
+                  "code": "initial-population",
+                  "system": "http://terminology.hl7.org/CodeSystem/measure-population"
+                }
+              ]
+            },
+            "criteria": {
+              "expression": "InInitialPopulation",
+              "language": "text/cql-identifier"
+            }
+          }
+        ],
+        "stratifier": [
+          {
+            "code": {
+              "text": "gender"
+            },
+            "criteria": {
+              "expression": "Gender",
+              "language": "text/cql"
+            }
+          },
+          {
+            "code": {
+              "text": "donor_age"
+            },
+            "criteria": {
+              "expression": "AgeClass",
+              "language": "text/cql"
+            }
+          },
+          {
+            "code": {
+              "text": "Custodian"
+            },
+            "criteria": {
+              "expression": "Custodian",
+              "language": "text/cql"
+            }
+          }
+        ]
+      },
+      {
+        "code": {
+          "text": "diagnosis"
+        },
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-populationBasis",
+            "valueCode": "Condition"
+          }
+        ],
+        "population": [
+          {
+            "code": {
+              "coding": [
+                {
+                  "code": "initial-population",
+                  "system": "http://terminology.hl7.org/CodeSystem/measure-population"
+                }
+              ]
+            },
+            "criteria": {
+              "expression": "Diagnosis",
+              "language": "text/cql-identifier"
+            }
+          }
+        ],
+        "stratifier": [
+          {
+            "code": {
+              "text": "diagnosis"
+            },
+            "criteria": {
+              "expression": "DiagnosisCode",
+              "language": "text/cql"
+            }
+          }
+        ]
+      },
+      {
+        "code": {
+          "text": "specimen"
+        },
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-populationBasis",
+            "valueCode": "Specimen"
+          }
+        ],
+        "population": [
+          {
+            "code": {
+              "coding": [
+                {
+                  "code": "initial-population",
+                  "system": "http://terminology.hl7.org/CodeSystem/measure-population"
+                }
+              ]
+            },
+            "criteria": {
+              "expression": "Specimen",
+              "language": "text/cql-identifier"
+            }
+          }
+        ],
+        "stratifier": [
+          {
+            "code": {
+              "text": "sample_kind"
+            },
+            "criteria": {
+              "expression": "SampleType",
+              "language": "text/cql"
+            }
+          },
+          {
+            "code": {
+              "text": "storage_temperature"
+            },
+            "criteria": {
+              "expression": "StorageTemperature",
+              "language": "text/cql"
+            }
+          }
+        ]
+      }
+    ],
+    "library": "{{LIBRARY_UUID}}",
+    "resourceType": "Measure",
+    "scoring": {
+      "coding": [
+        {
+          "code": "cohort",
+          "system": "http://terminology.hl7.org/CodeSystem/measure-scoring"
+        }
+      ]
+    },
+    "status": "active",
+    "subjectCodeableConcept": {
+      "coding": [
+        {
+          "code": "Patient",
+          "system": "http://hl7.org/fhir/resource-types"
+        }
+      ]
+    },
+    "url": "{{MEASURE_UUID}}"
+  }
+}

--- a/src/flavours/miabis/mod.rs
+++ b/src/flavours/miabis/mod.rs
@@ -1,26 +1,115 @@
-// TODO: put miabis stuff here
-
 use std::{collections::HashMap, sync::LazyLock};
 
 use indexmap::IndexSet;
 
 use super::CriterionRole;
 
-pub static CODE_LISTS: LazyLock<HashMap<&'static str, &'static str>> =
-    LazyLock::new(|| HashMap::new());
+pub static CODE_LISTS: LazyLock<HashMap<&'static str, &'static str>> = LazyLock::new(|| {
+    HashMap::from([
+        ("icd10", "http://hl7.org/fhir/sid/icd-10"),
+        (
+            "MiabisDetailedSampleType",
+            "https://fhir.bbmri-eric.eu/CodeSystem/miabis-detailed-samply-type-cs",
+        ),
+    ])
+});
 
 pub static OBSERVATION_LOINC_CODES: LazyLock<HashMap<&'static str, &'static str>> =
-    LazyLock::new(|| HashMap::new());
+    LazyLock::new(HashMap::new);
 
 pub static CRITERION_CODE_LISTS: LazyLock<HashMap<&'static str, Vec<&'static str>>> =
-    LazyLock::new(|| HashMap::new());
+    LazyLock::new(|| {
+        HashMap::from([
+            ("diagnosis", vec!["icd10"]),
+            ("sample_kind", vec!["MiabisDetailedSampleType"]),
+        ])
+    });
 
 pub static CQL_SNIPPETS: LazyLock<HashMap<(&'static str, CriterionRole), &'static str>> =
-    LazyLock::new(|| HashMap::new());
+    LazyLock::new(|| {
+        HashMap::from([
+            (("gender", CriterionRole::Query), "Patient.gender = '{{C}}'"),
+            (
+                ("diagnosis", CriterionRole::Query),
+                "exists[Condition: Code '{{C}}' from {{A1}}]",
+            ),
+            (
+                ("date_of_diagnosis", CriterionRole::Query),
+                "exists from [Condition] C\nwhere FHIRHelpers.ToDateTime(C.onset) between {{D1}} and {{D2}}",
+            ),
+            (
+                ("diagnosis_age_donor", CriterionRole::Query),
+                "exists from [Condition] C\nwhere AgeInYearsAt(FHIRHelpers.ToDateTime(C.onset)) between Ceiling({{D1}}) and Ceiling({{D2}})",
+            ),
+            (
+                ("donor_age", CriterionRole::Query),
+                "AgeInYears() between Ceiling({{D1}}) and Ceiling({{D2}})",
+            ),
+            (
+                ("sample_kind", CriterionRole::Query),
+                "exists [Specimen: Code '{{C}}' from {{A1}}]",
+            ),
+            (
+                ("sample_kind", CriterionRole::Filter),
+                "(S.type.coding.where(system = 'https://fhir.bbmri-eric.eu/CodeSystem/miabis-detailed-samply-type-cs').code contains '{{C}}')",
+            ),
+            (
+                ("storage_temperature", CriterionRole::Query),
+                "exists from [Specimen] S where (\
+                    exists from S.processing P where (\
+                        exists from P.extension E where \
+                            E.url = 'https://fhir.bbmri-eric.eu/StructureDefinition/miabis-sample-storage-temperature-extension' \
+                            and (E.value as CodeableConcept).coding.code contains '{{C}}'\
+                    )\
+                )",
+            ),
+            (
+                ("storage_temperature", CriterionRole::Filter),
+                "(exists from S.processing P where (\
+                    exists from P.extension E where \
+                        E.url = 'https://fhir.bbmri-eric.eu/StructureDefinition/miabis-sample-storage-temperature-extension' \
+                        and (E.value as CodeableConcept).coding.code contains '{{C}}'\
+                ))",
+            ),
+            (
+                ("sampling_date", CriterionRole::Query),
+                "exists from [Specimen] S\nwhere FHIRHelpers.ToDateTime(S.collection.collected) between {{D1}} and {{D2}}",
+            ),
+            (
+                ("sampling_date", CriterionRole::Filter),
+                "(FHIRHelpers.ToDateTime(S.collection.collected) between {{D1}} and {{D2}})",
+            ),
+        ])
+    });
 
 pub static MANDATORY_CODE_LISTS: LazyLock<IndexSet<&'static str>> =
-    LazyLock::new(|| IndexSet::new());
+    LazyLock::new(|| IndexSet::from(["icd10", "MiabisDetailedSampleType"]));
 
 pub static CODE_WORKAROUNDS: LazyLock<HashMap<&'static str, Vec<&'static str>>> =
-    // both sample type and storage temperature replacement codes
-    LazyLock::new(|| HashMap::new());
+    LazyLock::new(|| {
+        HashMap::from([
+            ("whole-blood", vec!["WholeBlood"]),
+            ("buffy-coat", vec!["BuffyCoat"]),
+            ("blood-plasma", vec!["Plasma"]),
+            ("blood-serum", vec!["Serum"]),
+            ("dna", vec!["DNA"]),
+            ("rna", vec!["RNA"]),
+            ("peripheral-blood-cells-vital", vec!["PBMC"]),
+            ("tissue-frozen", vec!["TissueFreshFrozen"]),
+            ("tissue-ffpe", vec!["TissueFixed"]),
+            ("bone-marrow", vec!["BoneMarrowAspirate"]),
+            ("csf-liquor", vec!["CerebrospinalFluid"]),
+            ("urine", vec!["Urine"]),
+            ("saliva", vec!["Saliva"]),
+            ("stool-faeces", vec!["Faeces"]),
+            ("liquid-other", vec!["LiquidBiopsy", "Sputum"]),
+            ("temperatureRoom", vec!["RT"]),
+            ("temperature2to10", vec!["2to10"]),
+            ("four_degrees", vec!["2to10"]),
+            ("temperature-18to-35", vec!["-18to-35"]),
+            ("temperature-60to-85", vec!["-60to-85"]),
+            ("temperatureGN", vec!["LN"]),
+            ("temperatureLN", vec!["LN"]),
+            ("temperatureOther", vec!["Other"]),
+        ])
+    });

--- a/src/flavours/miabis/template.cql
+++ b/src/flavours/miabis/template.cql
@@ -1,1 +1,67 @@
-//replace with miabis template
+library Retrieve
+using FHIR version '4.0.1'
+include FHIRHelpers version '4.0.1'
+
+{{lists}}
+
+context Patient
+
+define AgeClass:
+if (Patient.birthDate is null) then 'unknown' else ToString((AgeInYears() div 10) * 10)
+
+define Gender:
+if (Patient.gender is null) then 'unknown' else Patient.gender
+
+define Custodian:
+    First(
+        from Specimen.extension E
+        where E.url = 'https://fhir.bbmri-eric.eu/StructureDefinition/miabis-sample-collection-extension'
+        return (E.value as Identifier).value
+    )
+
+define function SampleType(specimen FHIR.Specimen):
+    case FHIRHelpers.ToCode(specimen.type.coding.where(system = 'https://fhir.bbmri-eric.eu/CodeSystem/miabis-detailed-samply-type-cs').first())
+       when Code 'WholeBlood'         from MiabisDetailedSampleType then 'whole-blood'
+       when Code 'BuffyCoat'          from MiabisDetailedSampleType then 'buffy-coat'
+       when Code 'Plasma'             from MiabisDetailedSampleType then 'blood-plasma'
+       when Code 'Serum'              from MiabisDetailedSampleType then 'blood-serum'
+       when Code 'DNA'                from MiabisDetailedSampleType then 'dna'
+       when Code 'RNA'                from MiabisDetailedSampleType then 'rna'
+       when Code 'PBMC'               from MiabisDetailedSampleType then 'peripheral-blood-cells-vital'
+       when Code 'TissueFreshFrozen'  from MiabisDetailedSampleType then 'tissue-frozen'
+       when Code 'TissueFixed'        from MiabisDetailedSampleType then 'tissue-ffpe'
+       when Code 'BoneMarrowAspirate' from MiabisDetailedSampleType then 'bone-marrow'
+       when Code 'CerebrospinalFluid' from MiabisDetailedSampleType then 'csf-liquor'
+       when Code 'Urine'              from MiabisDetailedSampleType then 'urine'
+       when Code 'Saliva'             from MiabisDetailedSampleType then 'saliva'
+       when Code 'Faeces'             from MiabisDetailedSampleType then 'stool-faeces'
+       when Code 'LiquidBiopsy'       from MiabisDetailedSampleType then 'liquid-other'
+       when Code 'Sputum'             from MiabisDetailedSampleType then 'liquid-other'
+       when null                      then 'Unknown'
+       else                                'Unknown'
+    end
+
+define StorageTemperature:
+    First(
+        from Specimen.processing P
+        return First(
+            from P.extension E
+            where E.url = 'https://fhir.bbmri-eric.eu/StructureDefinition/miabis-sample-storage-temperature-extension'
+            return FHIRHelpers.ToString((E.value as CodeableConcept).coding.first().code)
+        )
+    )
+
+define Specimen:
+    if InInitialPopulation then [Specimen] S {{filter_criteria}} else {} as List<Specimen>
+
+define Diagnosis:
+    if InInitialPopulation then [Condition] else {} as List<Condition>
+
+define function DiagnosisCode(condition FHIR.Condition, specimen FHIR.Specimen):
+    condition.code.coding.where(system = 'http://hl7.org/fhir/sid/icd-10').code.first()
+
+define function DiagnosisCode(condition FHIR.Condition):
+    condition.code.coding.where(system = 'http://hl7.org/fhir/sid/icd-10').code.first()
+
+define InInitialPopulation:
+{{retrieval_criteria}}

--- a/src/main.rs
+++ b/src/main.rs
@@ -315,8 +315,6 @@ async fn process_task(
     match CONFIG.endpoint_type {
         EndpointType::Blaze => {
             let mut generated_from_ast: bool = false;
-            // Support both old format (base64({"lang":"ast","payload":"b64(ast)"}))
-            // and new Spot 0.2.x format (raw {"ast":{...},"id":"..."} or {"lang":"ast","payload":"b64(ast)"})
             let data = match base64_decode(&task.body) {
                 Ok(d) => d,
                 Err(_) => task.body.as_bytes().to_vec(),
@@ -347,7 +345,6 @@ async fn process_task(
                     )?)?
                 }
                 Err(_) => {
-                    // New Spot 0.2.x format: raw ast::Operation JSON (operand + children, no wrapper or base64)
                     generated_from_ast = true;
                     let cql_flavour = if let Some(cql_flavour) = CONFIG.cql_flavour {
                         cql_flavour

--- a/src/main.rs
+++ b/src/main.rs
@@ -315,9 +315,14 @@ async fn process_task(
     match CONFIG.endpoint_type {
         EndpointType::Blaze => {
             let mut generated_from_ast: bool = false;
-            let data = base64_decode(&task.body)?;
-            let query: CqlQuery = match serde_json::from_slice::<Language>(&data)? {
-                Language::Cql(cql_query) => {
+            // Support both old format (base64({"lang":"ast","payload":"b64(ast)"}))
+            // and new Spot 0.2.x format (raw {"ast":{...},"id":"..."} or {"lang":"ast","payload":"b64(ast)"})
+            let data = match base64_decode(&task.body) {
+                Ok(d) => d,
+                Err(_) => task.body.as_bytes().to_vec(),
+            };
+            let query: CqlQuery = match serde_json::from_slice::<Language>(&data) {
+                Ok(Language::Cql(cql_query)) => {
                     if CONFIG
                         .cql_projects_enabled
                         .as_ref()
@@ -328,7 +333,7 @@ async fn process_task(
                         return Err(FocusError::CqlLangNotEnabled);
                     }
                 }
-                Language::Ast(ast_query) => {
+                Ok(Language::Ast(ast_query)) => {
                     generated_from_ast = true;
                     let cql_flavour = if let Some(cql_flavour) = CONFIG.cql_flavour {
                         //same FEs query blazes with different FHIR profiles
@@ -340,6 +345,18 @@ async fn process_task(
                         parse_blaze_query_payload_ast(&ast_query.payload)?,
                         cql_flavour,
                     )?)?
+                }
+                Err(_) => {
+                    // New Spot 0.2.x format: raw ast::Operation JSON (operand + children, no wrapper or base64)
+                    generated_from_ast = true;
+                    let cql_flavour = if let Some(cql_flavour) = CONFIG.cql_flavour {
+                        cql_flavour
+                    } else {
+                        metadata.project.parse()?
+                    };
+                    let operation: ast::Operation = serde_json::from_slice(&data)?;
+                    let wrapped = ast::Ast { ast: operation, id: task.id.to_string() };
+                    serde_json::from_str(&cql::generate_body(wrapped, cql_flavour)?)?
                 }
             };
             run_cql_query(

--- a/src/main.rs
+++ b/src/main.rs
@@ -315,12 +315,9 @@ async fn process_task(
     match CONFIG.endpoint_type {
         EndpointType::Blaze => {
             let mut generated_from_ast: bool = false;
-            let data = match base64_decode(&task.body) {
-                Ok(d) => d,
-                Err(_) => task.body.as_bytes().to_vec(),
-            };
-            let query: CqlQuery = match serde_json::from_slice::<Language>(&data) {
-                Ok(Language::Cql(cql_query)) => {
+            let data = base64_decode(&task.body)?;
+            let query: CqlQuery = match serde_json::from_slice::<Language>(&data)? {
+                Language::Cql(cql_query) => {
                     if CONFIG
                         .cql_projects_enabled
                         .as_ref()
@@ -331,7 +328,7 @@ async fn process_task(
                         return Err(FocusError::CqlLangNotEnabled);
                     }
                 }
-                Ok(Language::Ast(ast_query)) => {
+                Language::Ast(ast_query) => {
                     generated_from_ast = true;
                     let cql_flavour = if let Some(cql_flavour) = CONFIG.cql_flavour {
                         //same FEs query blazes with different FHIR profiles
@@ -343,17 +340,6 @@ async fn process_task(
                         parse_blaze_query_payload_ast(&ast_query.payload)?,
                         cql_flavour,
                     )?)?
-                }
-                Err(_) => {
-                    generated_from_ast = true;
-                    let cql_flavour = if let Some(cql_flavour) = CONFIG.cql_flavour {
-                        cql_flavour
-                    } else {
-                        metadata.project.parse()?
-                    };
-                    let operation: ast::Operation = serde_json::from_slice(&data)?;
-                    let wrapped = ast::Ast { ast: operation, id: task.id.to_string() };
-                    serde_json::from_str(&cql::generate_body(wrapped, cql_flavour)?)?
                 }
             };
             run_cql_query(


### PR DESCRIPTION
  ## Summary

  Adds a `Flavour::Miabis` CQL flavour to focus, enabling sites running
  MIABIS-on-FHIR v1.0.0 data to participate in federated Sample Locator
  searches without any changes to Spot.

  ### What's included

  - `src/flavours/miabis/template.cql` — CQL template for MIABIS-on-FHIR
  - `src/flavours/miabis/body.json` — FHIR Measure/Library skeleton
  - `src/flavours/miabis/mod.rs` — code lists, combined `CODE_WORKAROUNDS` map, snippets

  ### Key design decisions

  **`context Patient` throughout** — In `context Specimen`, `FHIRHelpers.ToString(Coding.code)`
  returns null due to a Blaze 1.5.x primitive-storage difference. Using `context Patient`
  with `define Specimen: [Specimen]` avoids this.

  **Storage temperature in `Specimen.processing[].extension`** — The MIABIS IG places
  storage temperature inside `processing[].extension`, not directly on `Specimen.extension`.
  Uses nested `from P.extension E where E.url = '...'` to avoid a Blaze `"name cannot be null"` crash.

  **Single `CODE_WORKAROUNDS` map** — Sample type + storage temperature workarounds are
  merged into one map (their code spaces don't overlap). For MIABIS, Lens canonical codes
  are *replaced* by MIABIS codes (not appended). Replace-not-append semantics are applied
  in the `ConditionType::In` and `ConditionType::Equals` arms of `cql.rs`.

  **`CQL_FLAVOUR` env var** — Sites set `CQL_FLAVOUR=miabis` in their focus config to
  select this template. Spot continues to send `metadata.project = "bbmri"` unchanged;
  no Spot changes required.

  ### Deployment

  Sites set `CQL_FLAVOUR=miabis` in their focus environment. Legacy BBMRI.de sites are
  unaffected. Mixed deployments (some MIABIS, some BBMRI.de) work without coordination.

  ### Testing

  7 unit tests added, all passing:
  - `test_miabis_empty` — mandatory code systems always declared
  - `test_miabis_gender` — Patient.gender snippet
  - `test_miabis_diagnosis` — ICD-10 codes; ICD-10-GM variants absent
  - `test_miabis_sample_kind` — canonical + TissueFixed workaround
  - `test_miabis_storage_temperature` — `processing[].extension` path
  - `test_miabis_sample_type_workarounds` — blood-plasma→Plasma, liquid-other→LiquidBiopsy+Sputum
  - `test_miabis_storage_temperature_workarounds` — temperatureRoom→RT, four_degrees→2to10, temperatureGN→LN

  E2E tests (two-site mixed MIABIS + BBMRI.de stack) live in samply/headlights under `bbmri-miabis/`.
